### PR TITLE
Issue parsing SLD TextSymbolizer -> PropertyName

### DIFF
--- a/scripts/tests/SLD/1.0.0/example-sld-propertyname.xml
+++ b/scripts/tests/SLD/1.0.0/example-sld-propertyname.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<StyledLayerDescriptor version="1.0.0" xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc"
+  xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.0.0/StyledLayerDescriptor.xsd">
+  <NamedLayer>
+    <Name>Default Point</Name>
+    <UserStyle>
+      <FeatureTypeStyle>
+        <Rule>
+          <PointSymbolizer>
+            <Graphic>
+              <Mark>
+                <WellKnownName>circle</WellKnownName>
+                <Fill>
+                  <CssParameter name="fill">#ff0000</CssParameter>
+                  <CssParameter name="fill-opacity">0.8</CssParameter>
+                </Fill>
+                <Stroke>
+                  <CssParameter name="stroke">#ffff00</CssParameter>
+                  <CssParameter name="stroke-width">3</CssParameter>
+                  <CssParameter name="stroke-opacity">0.9</CssParameter>
+                </Stroke>
+              </Mark>
+              <Size>10</Size>
+            </Graphic>
+          </PointSymbolizer>
+       <TextSymbolizer>
+         <Label>
+           <ogc:PropertyName>name</ogc:PropertyName>
+         </Label>
+         <Font>
+           <CssParameter name="font-family">Arial</CssParameter>
+           <CssParameter name="font-size">12</CssParameter>
+           <CssParameter name="font-style">normal</CssParameter>
+           <CssParameter name="font-weight">bold</CssParameter>
+         </Font>
+         <LabelPlacement>
+           <PointPlacement>
+             <AnchorPoint>
+               <AnchorPointX>0.5</AnchorPointX>
+               <AnchorPointY>0.0</AnchorPointY>
+             </AnchorPoint>
+             <Displacement>
+               <DisplacementX>0</DisplacementX>
+               <DisplacementY>25</DisplacementY>
+             </Displacement>
+             <Rotation>-45</Rotation>
+           </PointPlacement>
+         </LabelPlacement>
+         <Fill>
+           <CssParameter name="fill">#990099</CssParameter>
+         </Fill>
+       </TextSymbolizer>
+        </Rule>
+      </FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>


### PR DESCRIPTION
When parsing content like:

```
       <TextSymbolizer>
         <Label>
           <ogc:PropertyName>name</ogc:PropertyName>
         </Label>
```

JSONIX seems to not resolve the value of PropertyName:

![screen shot 2014-12-11 at 15 37 03](https://cloud.githubusercontent.com/assets/319678/5395662/94d9f8b8-814b-11e4-895c-abc7c7117003.png)
