### PR TITLE
Error: Prefix [foo] of the QName [foo:states] is not bound in this context.

### DIFF
--- a/scripts/tests/WPS/1.0.0/WPS_1_0_0.js
+++ b/scripts/tests/WPS/1.0.0/WPS_1_0_0.js
@@ -2,6 +2,12 @@ var Jsonix = require('jsonix').Jsonix;
 var XLink_1_0 = require('w3c-schemas').XLink_1_0;
 var OWS_1_1_0 = require('../../../ogc-schemas').OWS_1_1_0;
 var WPS_1_0_0 = require('../../../ogc-schemas').WPS_1_0_0;
+var Filter_1_1_0 = require('../../../ogc-schemas').Filter_1_1_0;
+var OWS_1_0_0 = require('../../../ogc-schemas').OWS_1_0_0;
+var SMIL_2_0 = require('../../../ogc-schemas').SMIL_2_0;
+var SMIL_2_0_Language = require('../../../ogc-schemas').SMIL_2_0_Language;
+var GML_3_1_1 = require('../../../ogc-schemas').GML_3_1_1;
+var WFS_1_1_0 = require('../../../ogc-schemas').WFS_1_1_0;
 
 var roundtrip = require('../../roundtrip').roundtrip;
 var mappings = [XLink_1_0, OWS_1_1_0, WPS_1_0_0];
@@ -18,6 +24,89 @@ module.exports = {
 			test.done();
 		});
 	},
+        "MarshalWithQName": function(test) {
+                var context = new Jsonix.Context([
+                    XLink_1_0,
+                    OWS_1_1_0,
+                    Filter_1_1_0,
+                    OWS_1_0_0,
+                    SMIL_2_0,
+                    SMIL_2_0_Language,
+                    GML_3_1_1,
+                    WFS_1_1_0,
+                    WPS_1_0_0
+                ], {
+                    namespacePrefixes : {
+                        'http://www.w3.org/1999/xlink' : 'xlink',
+                        'http://www.opengis.net/wps/1.0.0' : 'wps',
+                        'http://www.opengis.net/ows/1.1' : 'ows',
+                        'http://www.opengis.net/wfs': 'wfs',
+                        'http://www.opengeospatial.net/cite': 'cite'
+                        }
+                    }
+                );
+                var data = {
+                              "name": {
+                                "localPart": "Execute",
+                                "namespaceURI": "http://www.opengis.net/wps/1.0.0"
+                              },
+                              "value": {
+                                "service": "WPS",
+                                "version": "1.0.0",
+                                "identifier": {
+                                  "value": "vec:FeatureClassStats"
+                                },
+                                "responseForm": {
+                                  "rawDataOutput": {
+                                    "identifier": {
+                                      "value": "results"
+                                    }
+                                  }
+                                },
+                                "dataInputs": {
+                                  "input": [
+                                    {
+                                      "identifier": {
+                                        "value": "features"
+                                      },
+                                      "reference": {
+                                        "method": "POST",
+                                        "mimeType": "text/xml",
+                                        "href": "http://geoserver/wfs",
+                                        "body": {
+                                          "content": [
+                                            {
+                                              "name": {
+                                                "namespaceURI": "http://www.opengis.net/wfs",
+                                                "localPart": "GetFeature"
+                                              },
+                                              "value": {
+                                                "outputFormat": "GML2",
+                                                "service": "WFS",
+                                                "version": "1.1.0",
+                                                "query": [
+                                                  {
+                                                    "typeName": [
+                                                      "cite:states"
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            };
+                var marshaller = context.createMarshaller();
+                var marshalled = marshaller.marshalString(data);
+                test.equals(1, marshalled.indexOf('Execute'));
+                console.log(marshalled);
+                test.done();
+        },
 	"Roundtrips" : {
 		"Execute-01.xml" : function(test) {roundtrip(test, mappings, "tests/WPS/1.0.0/Execute-01.xml");}
 	}


### PR DESCRIPTION
I am trying to write out a WPS request with an embedded WFS request but even though I define the namespace in namespacePrefixes, JSONIX is complaining that it's not set:

```
                    this.context = new Jsonix.Context([
                            XLink_1_0,
                            OWS_1_1_0,
                            Filter_1_1_0,
                            OWS_1_0_0,
                            SMIL_2_0,
                            SMIL_2_0_Language,
                            GML_3_1_1,
                            WFS_1_1_0,
                            WPS_1_0_0
                        ], {
                        namespacePrefixes : {
                            'http://foo': 'foo',
                            'http://www.w3.org/1999/xlink' : 'xlink',
                            'http://www.opengis.net/wps/1.0.0' : 'wps',
                            'http://www.opengis.net/ows/1.1' : 'ows'
                        }
                    });
```

JSON config:

```
{"name":{"localPart":"Execute","namespaceURI":"http://www.opengis.net/wps/1.0.0"},"value":{"service":"WPS","version":"1.0.0","identifier":{"value":"vec:FeatureClassStats"},"responseForm":{"rawDataOutput":{"identifier":{"value":"results"}}},"dataInputs":{"input":[{"identifier":{"value":"features"},"reference":{"method":"POST","mimeType":"text/xml","href":"http://geoserver/wfs","body":{"content":[{"name":{"namespaceURI":"http://www.opengis.net/wfs","localPart":"GetFeature"},"value":{"outputFormat":"GML2","service":"WFS","version":"1.1.0","query":[{"typeName":["foo:states"]}]}}]}}},{"identifier":{"value":"attribute"},"data":{"literalData":{"value":"POPULATION"}}},{"identifier":{"value":"classes"},"data":{"literalData":{"value":10}}},{"identifier":{"value":"method"},"data":{"literalData":{"value":"EQUAL_INTERVAL"}}},{"identifier":{"value":"stats"},"data":{"literalData":{"value":"mean"}}}]}}}
```
