### PR TITLE
Updated WPS 2.0 schemas to authorative ones provided by the OGC for version 2.0.0

### DIFF
--- a/schemas/src/main/resources-original/ogc/wps/2.0/dataTypes.xsd
+++ b/schemas/src/main/resources-original/ogc/wps/2.0/dataTypes.xsd
@@ -1,33 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-    OGC LICENSE HEADER
-
-    The official OGC XML schemas can be accessed under http://schemas.opengis.net.
-    Please consider the schema copyright notices: http://www.opengeospatial.org/ogc/document
-    and the OGC Copyright Notice and Disclaimers: http://www.opengeospatial.org/ogc/legal
-    If there are any questions left there is also a copyright FAQ: http://www.opengeospatial.org/ogc/legalfaq
--->
-<schema xmlns="http://www.w3.org/2001/XMLSchema"
+<schema
+	xmlns="http://www.w3.org/2001/XMLSchema"
 	xmlns:ows="http://www.opengis.net/ows/2.0"
-	xmlns:wps="http://www.opengis.net/wps/2.0.0"
-	targetNamespace="http://www.opengis.net/wps/2.0.0"
+	xmlns:wps="http://www.opengis.net/wps/2.0"
+	targetNamespace="http://www.opengis.net/wps/2.0"
 	xml:lang="en"
-	version="1.0.0">
+	version="2.0.0">
+	
 	<annotation>
-		<appinfo>$Id: dataTypes.xsd 2014-05-20 $</appinfo>
 		<documentation>
-			<description>This XML Schema Document defines basic data types for WPS.</description>
-			<copyright>
-				WPS is an OGC Standard.
-				Copyright (c) 2014 Open Geospatial Consortium.
-				To obtain additional rights of use, visit
-				http://www.opengeospatial.org/legal/ .
-			</copyright>
+			WPS is an OGC Standard.
+			Copyright (c) 2015 Open Geospatial Consortium.
+			To obtain additional rights of use, visit http://www.opengeospatial.org/legal/.
 		</documentation>
 	</annotation>
 	
+	<!-- all-components document include (OGC 06-135r11 s#14) -->
+	<include schemaLocation="wps.xsd"/>
+	
 	<!-- === IMPORTS === -->
-	<import namespace="http://www.opengis.net/ows/2.0" schemaLocation="http://schemas.opengis.net/ows/2.0/owsCommon.xsd" />
+	<import namespace="http://www.opengis.net/ows/2.0" schemaLocation="http://schemas.opengis.net/ows/2.0/owsAll.xsd" />
 	<include schemaLocation="processDescription.xsd"/>
 	
 	<!-- =========================================================== -->
@@ -41,8 +33,8 @@
 					<element name="LiteralDataDomain" maxOccurs="unbounded">
 						<annotation>
 							<documentation>
-								Literal Data inputs and outputs may be specified for several domains, i.e. distance units in meters, kilometers and feet.
-								One of these must be the default domain.
+								Literal Data inputs and outputs may be specified for several domains, e.g. distance units in meters,
+								kilometers and feet. One of these must be the default domain.
 							</documentation>
 						</annotation>
 						<complexType>
@@ -86,21 +78,29 @@
 	<element name="LiteralValue">
 		<complexType>
 			<annotation>
-				<documentation>One simple literal value (such as an integer or real number) that is embedded in the Execute operation request or response. </documentation>
+				<documentation>
+					Representation of a simple literal value (such as an integer, a real number, or a string).
+				</documentation>
 			</annotation>
 			<simpleContent>
 				<extension base="ows:ValueType">
 					<annotation>
-						<documentation>String containing the Literal value (e.g., "49").</documentation>
+						<documentation>
+							String representation of the actual value (e.g., "49").
+						</documentation>
 					</annotation>
 					<attribute name="dataType" type="anyURI" use="optional">
 						<annotation>
-							<documentation>Identifies the data type of this literal input or output. This dataType should be included for each quantity whose value is not a simple string. </documentation>
+							<documentation>
+								The data type of the value.
+							</documentation>
 						</annotation>
 					</attribute>
 					<attribute name="uom" type="anyURI" use="optional">
 						<annotation>
-							<documentation>Identifies the value unit of this literal input or output. Shall be a value unit identified in the Process description for this input or output. </documentation>
+							<documentation>
+								The unit of measurement of the value.
+							</documentation>
 						</annotation>
 					</attribute>
 				</extension>
@@ -142,7 +142,7 @@
 	<element name="SupportedCRS">
 		<annotation>
 			<documentation>
-				Supported  CRS supported for this Input/Output. "default" shall be used
+				Supported CRS supported for this Input/Output. "default" shall be used
 				on only one element. This default element identifies the default CRS.
 			</documentation>
 		</annotation>
@@ -162,15 +162,8 @@
 	<element name="ComplexData" type="wps:ComplexDataType" substitutionGroup="wps:DataDescription">
 		<annotation>
 			<documentation>
-				Indicates that this input/output shall be a complex data
-				structure (such as a GML document), and provides a list of
-				Formats, Encodings, and Schemas supported for this input/output. The
-				value of this ComplexData structure can be input either embedded
-				in the Execute request or remotely accessible to the server. The
-				client can select from among the identified combinations of
-				Formats, Encodings, and Schemas to specify the form of the input/output.
-				This allows for complete specification of particular versions of
-				GML, or image formats.
+				Indicates that this input/output shall be a complex data structure
+				(such as a GML document or a GeoTiff image that comply with a particular format definition).
 			</documentation>
 		</annotation>
 	</element>
@@ -179,6 +172,11 @@
 		<complexContent>
 			<extension base="wps:DataDescriptionType">
 				<sequence>
+					<annotation>
+						<documentation>
+							Placeholder for schema extensions to WPS complex data.
+						</documentation>
+					</annotation>
 					<any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
 				</sequence>
 			</extension>

--- a/schemas/src/main/resources-original/ogc/wps/2.0/processDescription.xsd
+++ b/schemas/src/main/resources-original/ogc/wps/2.0/processDescription.xsd
@@ -1,58 +1,52 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-    OGC LICENSE HEADER
-
-    The official OGC XML schemas can be accessed under http://schemas.opengis.net.
-    Please consider the schema copyright notices: http://www.opengeospatial.org/ogc/document
-    and the OGC Copyright Notice and Disclaimers: http://www.opengeospatial.org/ogc/legal
-    If there are any questions left there is also a copyright FAQ: http://www.opengeospatial.org/ogc/legalfaq
--->
-<schema xmlns="http://www.w3.org/2001/XMLSchema"
+<schema
+	xmlns="http://www.w3.org/2001/XMLSchema"
 	xmlns:ows="http://www.opengis.net/ows/2.0"
-	xmlns:xlink="http://www.w3.org/1999/xlink"
-	xmlns:wps="http://www.opengis.net/wps/2.0.0"
-	targetNamespace="http://www.opengis.net/wps/2.0.0"
+	xmlns:wps="http://www.opengis.net/wps/2.0"
+	targetNamespace="http://www.opengis.net/wps/2.0"
 	elementFormDefault="qualified"
 	xml:lang="en"
-	version="1.0.0">
+	version="2.0.0">
+	
 	<annotation>
-		<appinfo>$Id: processDescription.xsd 2014-05-20 $</appinfo>
 		<documentation>
-			<description>Description of a Process, designed for Process identification and discovery.</description>
-			<copyright>
-				WPS is an OGC Standard.
-				Copyright (c) 2014 Open Geospatial Consortium.
-				To obtain additional rights of use, visit http://www.opengeospatial.org/legal/ .
-			</copyright>
+			WPS is an OGC Standard.
+			Copyright (c) 2015 Open Geospatial Consortium.
+			To obtain additional rights of use, visit http://www.opengeospatial.org/legal/.
 		</documentation>
 	</annotation>
 	
+	<!-- all-components document include (OGC 06-135r11 s#14) -->
+	<include schemaLocation="wps.xsd"/>
+	
 	<!-- === IMPORTS === -->
-	<import namespace="http://www.opengis.net/ows/2.0" schemaLocation="http://schemas.opengis.net/ows/2.0/owsCommon.xsd" />
+	<import namespace="http://www.opengis.net/ows/2.0" schemaLocation="http://schemas.opengis.net/ows/2.0/owsAll.xsd" />
 	<import namespace="http://www.w3.org/2001/XMLSchema" schemaLocation="http://www.w3.org/2001/XMLSchema.xsd" />
 	<import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="http://www.w3.org/2001/xml.xsd"/>
-	
-	<!-- Required for links in profiles -->
-	<import namespace="http://www.w3.org/1999/xlink" schemaLocation="http://www.w3.org/1999/xlink.xsd"/>
 	
 	<!-- =========================================================== -->
 	<!-- Description Type for elements in the process Description    -->
 	<!-- =========================================================== -->
 	<complexType name="DescriptionType">
 		<annotation>
-			<documentation>Description type for process or input/output data items.</documentation>
+			<documentation>
+				Description type for process or input/output data items.
+			</documentation>
 		</annotation>
 		<complexContent>
 			<restriction base="ows:BasicIdentificationType">
 				<sequence>
 					<element ref="ows:Title">
 						<annotation>
-							<documentation>Title of a process/input/output, normally available for display to a human. </documentation>
+							<documentation>
+								Title of a process/input/output, normally available for display to a human.
+							</documentation>
 						</annotation>
 					</element>
 					<element ref="ows:Abstract" minOccurs="0">
 						<annotation>
-							<documentation>Brief narrative description of a process or
+							<documentation>
+								Brief narrative description of a process or
 								data item, normally available for display to a human.
 							</documentation>
 						</annotation>
@@ -66,16 +60,17 @@
 					</element>
 					<element ref="ows:Identifier">
 						<annotation>
-							<documentation>Unambiguous identifier or name of a process,
-								unique for this server, or unambiguous identifier or name of a
-								data item, unique for a particular process. </documentation>
+							<documentation>
+								Unambiguous identifier of a process, input, and output.
+								Value is a plain URI or HTTP-URI. Use of additional attributes such as
+								code space and version attributes in the Identifier element are not allowed.
+							</documentation>
 						</annotation>
 					</element>
 					<element ref="ows:Metadata" minOccurs="0" maxOccurs="unbounded">
 						<annotation>
-							<documentation>Optional unordered list of additional metadata
-								about this process/input/output. A list of optional and/or
-								required metadata elements for this process/input/output.
+							<documentation>
+								Reference to additional metadata about this item.
 							</documentation>
 						</annotation>
 					</element>
@@ -124,7 +119,7 @@
 					</element>
 				</sequence>
 				<attribute ref="xml:lang">
-					<!-- (Copied from OWS Common) -->
+					<!-- (Definition adopted from OWS Common 2.0) -->
 					<annotation>
 						<documentation>
 							Identifier of a language used by the data(set) contents.
@@ -220,24 +215,30 @@
 			</annotation>
 			<attribute name="mimeType" type="ows:MimeType" use="optional">
 				<annotation>
-					<documentation>The Format of this input or requested for this output (e.g., text/xml). This element shall be omitted when the Format is indicated in the http header of the output. When included, this format shall be one published for this output or input in the Process full description. </documentation>
+					<documentation>
+						Media type of the data.
+					</documentation>
 				</annotation>
 			</attribute>
 			<attribute name="encoding" type="anyURI" use="optional">
 				<annotation>
-					<documentation>The encoding of this input or requested for this output (e.g., UTF-8). This "encoding" shall be included whenever the encoding required is not the default encoding indicated in the Process full description. When included, this encoding shall be one published for this output or input in the Process full description. </documentation>
+					<documentation>
+						Encoding procedure or character set of the data (e.g. raw or base64).
+					</documentation>
 				</annotation>
 			</attribute>
 			<attribute name="schema" type="anyURI" use="optional">
 				<annotation>
-					<documentation>Web-accessible XML Schema Document that defines the content model of this complex resource (e.g., encoded using GML 2.2 Application Schema).  This reference should be included for XML encoded complex resources. </documentation>
+					<documentation>
+						Identification of the data schema.
+					</documentation>
 				</annotation>
 			</attribute>
 			<attribute name="maximumMegabytes" type="positiveInteger" use="optional">
 					<annotation>
 						<documentation>
-							The maximum file size, in megabytes, of this input.
-							If the input exceeds this size, the server will return an error
+							The maximum size of the input data, in megabytes.
+							If the input exceeds this size, the server may return an error
 							instead of processing the inputs.
 						</documentation>
 					</annotation>

--- a/schemas/src/main/resources-original/ogc/wps/2.0/processProfile.xsd
+++ b/schemas/src/main/resources-original/ogc/wps/2.0/processProfile.xsd
@@ -1,38 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-    OGC LICENSE HEADER
-
-    The official OGC XML schemas can be accessed under http://schemas.opengis.net.
-    Please consider the schema copyright notices: http://www.opengeospatial.org/ogc/document
-    and the OGC Copyright Notice and Disclaimers: http://www.opengeospatial.org/ogc/legal
-    If there are any questions left there is also a copyright FAQ: http://www.opengeospatial.org/ogc/legalfaq
--->
-<schema xmlns="http://www.w3.org/2001/XMLSchema"
-	xmlns:ows="http://www.opengis.net/ows/2.0"
-	xmlns:xlink="http://www.w3.org/1999/xlink"
-	xmlns:wps="http://www.opengis.net/wps/2.0.0"
-	targetNamespace="http://www.opengis.net/wps/2.0.0"
+<schema
+	xmlns="http://www.w3.org/2001/XMLSchema"
+	xmlns:wps="http://www.opengis.net/wps/2.0"
+	targetNamespace="http://www.opengis.net/wps/2.0"
 	elementFormDefault="qualified"
 	xml:lang="en"
-	version="1.0.0">
+	version="2.0.0">
+	
 	<annotation>
-		<appinfo>$Id: processProfile.xsd 2014-01-31 $</appinfo>
 		<documentation>
-			<description>Description of a Process, designed for Process identification and discovery.</description>
-			<copyright>
-				WPS is an OGC Standard.
-				Copyright (c) 2014 Open Geospatial Consortium.
-				To obtain additional rights of use, visit http://www.opengeospatial.org/legal/ .
-			</copyright>
+			WPS is an OGC Standard.
+			Copyright (c) 2015 Open Geospatial Consortium.
+			To obtain additional rights of use, visit http://www.opengeospatial.org/legal/.
 		</documentation>
 	</annotation>
 	
-		<!-- === IMPORTS === -->
-	<import namespace="http://www.opengis.net/ows/2.0" schemaLocation="http://schemas.opengis.net/ows/2.0/owsCommon.xsd" />
-	<import namespace="http://www.w3.org/2001/XMLSchema" schemaLocation="http://www.w3.org/2001/XMLSchema.xsd" />
+	<!-- all-components document include (OGC 06-135r11 s#14) -->
+	<include schemaLocation="wps.xsd"/>
 	
-	<!-- Required for links in profiles -->
-	<import namespace="http://www.w3.org/1999/xlink" schemaLocation="http://www.w3.org/1999/xlink.xsd"/>
+	<!-- === IMPORTS === -->
+	<import namespace="http://www.w3.org/2001/XMLSchema" schemaLocation="http://www.w3.org/2001/XMLSchema.xsd" />
 	
 	<!-- === INCLUDES === -->
 	<include schemaLocation="processDescription.xsd"/>

--- a/schemas/src/main/resources-original/ogc/wps/2.0/wps.xsd
+++ b/schemas/src/main/resources-original/ogc/wps/2.0/wps.xsd
@@ -1,38 +1,33 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-    OGC LICENSE HEADER
-
-    The official OGC XML schemas can be accessed under http://schemas.opengis.net.
-    Please consider the schema copyright notices: http://www.opengeospatial.org/ogc/document
-    and the OGC Copyright Notice and Disclaimers: http://www.opengeospatial.org/ogc/legal
-    If there are any questions left there is also a copyright FAQ: http://www.opengeospatial.org/ogc/legalfaq
--->
-<schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:xs="http://www.w3.org/2001/XMLSchema"
-	xmlns:ows="http://www.opengis.net/ows/2.0" xmlns:wps="http://www.opengis.net/wps/2.0.0"
-	targetNamespace="http://www.opengis.net/wps/2.0.0" xml:lang="en"
+<schema
+	xmlns="http://www.w3.org/2001/XMLSchema"
+	xmlns:xs="http://www.w3.org/2001/XMLSchema"
+	xmlns:ows="http://www.opengis.net/ows/2.0"
+	xmlns:wps="http://www.opengis.net/wps/2.0"
+	targetNamespace="http://www.opengis.net/wps/2.0"
+	elementFormDefault="qualified"
+	xml:lang="en"
 	version="2.0.0">
+	
 	<annotation>
-		<appinfo>$Id: wps.xsd 2013-03-05 $</appinfo>
 		<documentation>
-			<description>This XML Schema Document encodes the WPS DescribeProcess
-				operation response.</description>
-			<copyright>
-				WPS is an OGC Standard.
-				Copyright (c) 2013 Open Geospatial Consortium.
-				To obtain additional rights of use, visit
-				http://www.opengeospatial.org/legal/ .
-			</copyright>
+			WPS is an OGC Standard.
+			Copyright (c) 2015 Open Geospatial Consortium.
+			To obtain additional rights of use, visit http://www.opengeospatial.org/legal/.
 		</documentation>
 	</annotation>
 	
 	<!-- === INCLUDES === -->
-	<include schemaLocation="wpsCommon.xsd"/>
+	<!-- All schemas for the process model, the service model encodings and the dismiss extension -->
 	<include schemaLocation="dataTypes.xsd"/>
 	<include schemaLocation="processDescription.xsd"/>
-	<include schemaLocation="wpsExecute.xsd"/>
+	<include schemaLocation="processProfile.xsd"/>
+	<include schemaLocation="wpsCommon.xsd"/>
 	<include schemaLocation="wpsGetCapabilities.xsd"/>
+	<include schemaLocation="wpsDescribeProcess.xsd"/>
+	<include schemaLocation="wpsExecute.xsd"/>
 	<include schemaLocation="wpsGetStatus.xsd"/>
+	<include schemaLocation="wpsGetResult.xsd"/>
 	<include schemaLocation="wpsDismiss.xsd"/>
 	
-	<!-- TODO: add remaining when finished -->
 </schema>

--- a/schemas/src/main/resources-original/ogc/wps/2.0/wpsCommon.xsd
+++ b/schemas/src/main/resources-original/ogc/wps/2.0/wpsCommon.xsd
@@ -1,40 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-    OGC LICENSE HEADER
-
-    The official OGC XML schemas can be accessed under http://schemas.opengis.net.
-    Please consider the schema copyright notices: http://www.opengeospatial.org/ogc/document
-    and the OGC Copyright Notice and Disclaimers: http://www.opengeospatial.org/ogc/legal
-    If there are any questions left there is also a copyright FAQ: http://www.opengeospatial.org/ogc/legalfaq
--->
-<schema xmlns="http://www.w3.org/2001/XMLSchema"
+<schema
+	xmlns="http://www.w3.org/2001/XMLSchema"
 	xmlns:ows="http://www.opengis.net/ows/2.0"
 	xmlns:xlink="http://www.w3.org/1999/xlink"
-	xmlns:wps="http://www.opengis.net/wps/2.0.0"
-	targetNamespace="http://www.opengis.net/wps/2.0.0"
+	xmlns:wps="http://www.opengis.net/wps/2.0"
+	targetNamespace="http://www.opengis.net/wps/2.0"
 	elementFormDefault="qualified"
 	xml:lang="en"
-	version="1.0.0">
+	version="2.0.0">
 	
 	<annotation>
-		<appinfo>$Id: wpsCommon.xsd 2014-05-20 $</appinfo>
 		<documentation>
-			<description>
-				This XML Schema Document encodes elements and types that
-				are shared by multiple WPS schema documents.
-			</description>
-			<copyright>
-				WPS is an OGC Standard.
-				Copyright (c) 2014 Open Geospatial Consortium.
-				To obtain additional rights of use, visit
-				http://www.opengeospatial.org/legal/ .
-			</copyright>
+			WPS is an OGC Standard.
+			Copyright (c) 2015 Open Geospatial Consortium.
+			To obtain additional rights of use, visit http://www.opengeospatial.org/legal/.
 		</documentation>
 	</annotation>
 	
+	<!-- all-components document include (OGC 06-135r11 s#14) -->
+	<include schemaLocation="wps.xsd"/>
 	
 	<!-- === IMPORTS === -->
-	<import namespace="http://www.opengis.net/ows/2.0" schemaLocation="http://schemas.opengis.net/ows/2.0/owsCommon.xsd" />
+	<import namespace="http://www.opengis.net/ows/2.0" schemaLocation="http://schemas.opengis.net/ows/2.0/owsAll.xsd"/>
 	<import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="http://www.w3.org/2001/xml.xsd"/>
 	<import namespace="http://www.w3.org/1999/xlink" schemaLocation="http://www.w3.org/1999/xlink.xsd"/>
 	
@@ -49,27 +36,35 @@
 	<complexType name="RequestBaseType" abstract="true">
 		<annotation>
 			<documentation>
-				WPS operation request base, for all WPS operations except GetCapabilities.
+				WPS operation request base, for all WPS operations, except GetCapabilities.
 				In this XML encoding, no "request" parameter is included, since the element
-				name specifies the specific operation. 'Extension' elements allow WPS extension
-				standards to define their individual extra request parameters.
+				name specifies the specific operation.
+				An 'Extension' element provides a placeholder for extra request parameters
+				that might be defined by WPS extension standards.
 			</documentation>
 		</annotation>
 		<sequence>
 			<element name="Extension" type="anyType" minOccurs="0" maxOccurs="unbounded">
 				<annotation>
-					<documentation>container for elements defined by extension specifications</documentation>
+					<documentation>
+						Any ancillary information to be sent from client to server.
+						Placeholder for further request parameters defined by WPS extension standards.
+					</documentation>
 				</annotation>
 			</element>
 		</sequence>
 		<attribute name="service" type="string" fixed="WPS" use="required" >
 			<annotation>
-				<documentation>Service type identifier (WPS)</documentation>
+				<documentation>
+					Service type identifier (WPS)
+				</documentation>
 			</annotation>
 		</attribute>
 		<attribute name="version" type="ows:VersionType" fixed="2.0.0" use="required">
 			<annotation>
-				<documentation>Version of the WPS interface specification implemented by the server (2.0.0)</documentation>
+				<documentation>
+					Version of the WPS interface specification implemented by the server (2.0.0)
+				</documentation>
 			</annotation>
 		</attribute>
 	</complexType>
@@ -81,29 +76,40 @@
 	<element name="Reference" type="wps:ReferenceType">
 		<annotation>
 			<documentation>
-				This element is used to make a direct reference to a data set or value.
+				This element is used for web accessible references to a data set or value.
 			</documentation>
 		</annotation>
 	</element>
 	<!-- =========================================================== -->
 	<complexType name="ReferenceType">
 		<annotation>
-			<documentation>Reference to an input (output) value that is a web accessible resource. </documentation>
+			<documentation>
+				Reference to an input (output) value that is a web accessible resource.
+			</documentation>
 		</annotation>
 		<choice minOccurs="0">
 			<element name="Body" type="anyType">
 				<annotation>
-					<documentation>The contents of this element to be used as the body of the HTTP request message to be sent to the service identified in ../Reference/@href.  For example, it could be an XML encoded WFS request using HTTP POST</documentation>
+					<documentation>
+						The contents of this element to be used as the body of the HTTP request
+						message to be sent to the service identified in ../Reference/@href. 
+						For example, it could be an XML encoded WFS request using HTTP/POST.
+					</documentation>
 				</annotation>
 			</element>
 			<element name="BodyReference">
 				<annotation>
-					<documentation>Reference to a remote document to be used as the body of the an HTTP POST request message to the service identified in ../Reference/@href.</documentation>
+					<documentation>
+						Reference to a remote document to be used as the body of the an HTTP/POST request message
+						to the service identified in the href element in the Reference structure.
+					</documentation>
 				</annotation>
 				<complexType>
 					<attribute ref="xlink:href" use="required">
 						<annotation>
-							<documentation>Reference to a remote document to be used as the body of the an HTTP POST request message. This attribute shall contain a URL from which this body can be electronically retrieved. </documentation>
+							<documentation>
+								HTTP URI that points to the remote resource where the request body may be retrieved.
+							</documentation>
 						</annotation>
 					</attribute>
 				</complexType>
@@ -111,7 +117,9 @@
 		</choice>
 		<attribute ref="xlink:href" use="required">
 			<annotation>
-				<documentation>Reference to a web-accessible resource that can be used as input, or is provided by the process as output. This attribute shall contain a URL from which this input (output) can be electronically retrieved. </documentation>
+				<documentation>
+					HTTP URI that points to the remote resource where the data may be retrieved.
+				</documentation>
 			</annotation>
 		</attribute>
 		<attributeGroup ref="wps:dataEncodingAttributes"/>
@@ -121,7 +129,8 @@
 		<complexType mixed="true">
 			<annotation>
 				<documentation>
-					This element is used to embed the data in a WPS request. The content can be XML data, plain character data, or specially encoded binary data (i.e. base64).
+					This element is used to embed the data in a WPS request or response.
+					The content can be XML data, plain character data, or specially encoded binary data (i.e. base64).
 				</documentation>
 			</annotation>
 			<complexContent mixed="true">
@@ -135,17 +144,23 @@
 	<attributeGroup name="dataEncodingAttributes">
 		<attribute name="mimeType" type="ows:MimeType" use="optional">
 			<annotation>
-				<documentation>The Format of this input or requested for this output (e.g., text/xml). This element shall be omitted when the Format is indicated in the http header of the output. When included, this format shall be one published for this output or input in the Process full description. </documentation>
+				<documentation>
+					Media type of the data.
+				</documentation>
 			</annotation>
 		</attribute>
 		<attribute name="encoding" type="anyURI" use="optional">
 			<annotation>
-				<documentation>The encoding of this input or requested for this output (e.g., UTF-8). This "encoding" shall be included whenever the encoding required is not the default encoding indicated in the Process full description. When included, this encoding shall be one published for this output or input in the Process full description. </documentation>
+				<documentation>
+					Encoding procedure or character set used (e.g. raw, base64, or UTF-8).
+				</documentation>
 			</annotation>
 		</attribute>
 		<attribute name="schema" type="anyURI" use="optional">
 			<annotation>
-				<documentation>Web-accessible XML Schema Document that defines the content model of this complex resource (e.g., encoded using GML 2.2 Application Schema).  This reference should be included for XML encoded complex resources. </documentation>
+				<documentation>
+					Identification of the data schema.
+				</documentation>
 			</annotation>
 		</attribute>
 	</attributeGroup>
@@ -179,10 +194,11 @@
 	<simpleType name="JobControlOptionsType">
 		<annotation>
 			<documentation>
-				This attribute type is used to specify process steering options. 
+				This attribute type is used to specify process control options. 
 				The WPS specification only defines "execute-sync" and "execute-async",
 				each with an associated execution protocol.
-				Extensions may specify additional steering options, i.e. for pausing and resuming processes.
+				Extensions may specify additional control options, such as "dimiss" which is
+				defined in the WPS dismiss extension.
 			</documentation>
 		</annotation>
 		<union>
@@ -190,10 +206,9 @@
 				<restriction base="string">
 					<enumeration value="sync-execute"/>
 					<enumeration value="async-execute"/>
-					<enumeration value="delete"/>
 				</restriction>
 			</simpleType>
-			<simpleType>
+ 			<simpleType>
 				<restriction base="string"/>
 			</simpleType>
 		</union>
@@ -215,15 +230,19 @@
 				<element ref="wps:JobID" minOccurs="0">
 					<annotation>
 						<documentation>
-							Include if required. From the WPS 1.0 Core document there are two cases:
-							a) asynchronous execution, where the job persists for some duration on the server
-							b) dismiss extension, where the client is allowed to actively free server-side resources
+							Include if required. A JobId is usually required for
+							a) asynchronous execution
+							b) the Dismiss operation extension, where the client is allowed to
+							   actively free server-side resources
 						</documentation>
 					</annotation>
 				</element>
 				<element ref="wps:ExpirationDate" minOccurs="0">
 					<annotation>
-						<documentation>Identifier of the Process that was executed. This Process identifier shall be as listed in the ProcessOfferings section of the WPS Capabilities document. </documentation>
+						<documentation>
+							Identifier of the Process that was executed.
+							This Process identifier shall be as listed in the ProcessOfferings
+							section of the WPS Capabilities document. </documentation>
 					</annotation>
 				</element>
 				<element name="Output" type="wps:DataOutputType" maxOccurs="unbounded"/>
@@ -276,42 +295,39 @@
 					<simpleType>
 						<annotation>
 							<documentation>
-								The type of status is basically a string. For convenience in documentation and code generation
-								it is realized as a union of
-								1) the pre-defined states defined in the WPS specification,
-								2) the simple type "string"
+								Basic status set to communicate the status of a server-side job to the client.
+								Extensions of this specification may introduce additional states for fine-grained
+								monitoring or domain-specific purposes.
 							</documentation>
 						</annotation>
 						<union>
 							<simpleType>
 								<restriction base="string">
-									<enumeration value="Accepted">
-										<annotation>
-											<documentation>
-												Indicates that the request for process execution was accepted.
-												Only used in response to an asynchronous execute request.
-											</documentation>
-										</annotation>
-									</enumeration>
-									<enumeration value="Running">
-										<annotation>
-											<documentation>
-												The process is running and has not yet finished.
-											</documentation>
-										</annotation>
-									</enumeration>
 									<enumeration value="Succeeded">
 										<annotation>
 											<documentation>
-												The process execution has finished and the results are available.
+												The job has finished with no errors.
 											</documentation>
 										</annotation>
 									</enumeration>
 									<enumeration value="Failed">
 										<annotation>
 											<documentation>
-												The process execution has finished but but failed. There will be no results
-												but only an exception report that can be inspected by the client.
+												The job has finished with errors.
+											</documentation>
+										</annotation>
+									</enumeration>
+									<enumeration value="Accepted">
+										<annotation>
+											<documentation>
+												The job is queued for execution. 
+											</documentation>
+										</annotation>
+									</enumeration>
+									<enumeration value="Running">
+										<annotation>
+											<documentation>
+												The job is running.
 											</documentation>
 										</annotation>
 									</enumeration>

--- a/schemas/src/main/resources-original/ogc/wps/2.0/wpsDescribeProcess.xsd
+++ b/schemas/src/main/resources-original/ogc/wps/2.0/wpsDescribeProcess.xsd
@@ -1,37 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-    OGC LICENSE HEADER
-
-    The official OGC XML schemas can be accessed under http://schemas.opengis.net.
-    Please consider the schema copyright notices: http://www.opengeospatial.org/ogc/document
-    and the OGC Copyright Notice and Disclaimers: http://www.opengeospatial.org/ogc/legal
-    If there are any questions left there is also a copyright FAQ: http://www.opengeospatial.org/ogc/legalfaq
--->
-<schema xmlns="http://www.w3.org/2001/XMLSchema"
+<schema
+	xmlns="http://www.w3.org/2001/XMLSchema"
 	xmlns:ows="http://www.opengis.net/ows/2.0"
-	xmlns:wps="http://www.opengis.net/wps/2.0.0"
-	targetNamespace="http://www.opengis.net/wps/2.0.0"
+	xmlns:wps="http://www.opengis.net/wps/2.0"
+	targetNamespace="http://www.opengis.net/wps/2.0"
 	elementFormDefault="qualified"
 	xml:lang="en"
-	version="1.0.0">
+	version="2.0.0">
 	<annotation>
-		<appinfo>$Id: wpsDescribeProcess.xsd 2014-05-20 $</appinfo>
 		<documentation>
-			<description>
-				This XML Schema Document encodes the WPS DescribeProcess
-				operation.
-			</description>
-			<copyright>
-				WPS is an OGC Standard.
-				Copyright (c) 2014 Open Geospatial Consortium.
-				To obtain additional rights of use, visit
-				http://www.opengeospatial.org/legal/ .
-			</copyright>
+			WPS is an OGC Standard.
+			Copyright (c) 2015 Open Geospatial Consortium.
+			To obtain additional rights of use, visit http://www.opengeospatial.org/legal/.
 		</documentation>
 	</annotation>
 	
+	<!-- all-components document include (OGC 06-135r11 s#14) -->
+	<include schemaLocation="wps.xsd"/>
+	
 	<!-- === IMPORTS === -->
-	<import namespace="http://www.opengis.net/ows/2.0" schemaLocation="http://schemas.opengis.net/ows/2.0/owsCommon.xsd" />
+	<import namespace="http://www.opengis.net/ows/2.0" schemaLocation="http://schemas.opengis.net/ows/2.0/owsAll.xsd"/>
 	<import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="http://www.w3.org/2001/xml.xsd"/>
 	
 	<!-- === INCLUDES === -->
@@ -60,7 +48,9 @@
 					</sequence>
 					<attribute ref="xml:lang" use="optional">
 						<annotation>
-							<documentation>RFC 4646 language code of the human-readable text (e.g. "en-CA") in the process description.</documentation>
+							<documentation>
+								RFC 4646 language code of the human-readable text (e.g. "en-CA") in the process description.
+							</documentation>
 						</annotation>
 					</attribute>
 				</extension>
@@ -97,8 +87,8 @@
 		<annotation>
 			<documentation>
 				A process offering is a process description. It has additional attributes that provide additional
-				information on how this process can be executed on a particular service instance (execution modes, data transmission modes,
-				informative process version.)
+				information on how this process can be executed on a particular service instance (execution modes,
+				data transmission modes, informative process version.)
 			</documentation>
 		</annotation>
 		<complexType>
@@ -134,7 +124,7 @@
 		<attribute name="outputTransmission">
 			<annotation>
 				<documentation>
-					Indicates if data outputs from this process	can be stored by the WPS server as web-accessible resources.
+					Indicates whether data outputs from this process can be stored by the WPS server as web-accessible resources.
 				</documentation>
 			</annotation>
 			<simpleType>

--- a/schemas/src/main/resources-original/ogc/wps/2.0/wpsDismiss.xsd
+++ b/schemas/src/main/resources-original/ogc/wps/2.0/wpsDismiss.xsd
@@ -1,29 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-    OGC LICENSE HEADER
-
-    The official OGC XML schemas can be accessed under http://schemas.opengis.net.
-    Please consider the schema copyright notices: http://www.opengeospatial.org/ogc/document
-    and the OGC Copyright Notice and Disclaimers: http://www.opengeospatial.org/ogc/legal
-    If there are any questions left there is also a copyright FAQ: http://www.opengeospatial.org/ogc/legalfaq
--->
-<schema xmlns="http://www.w3.org/2001/XMLSchema"
-	xmlns:ows="http://www.opengis.net/ows/2.0"
-	xmlns:wps="http://www.opengis.net/wps/2.0.0"
-	targetNamespace="http://www.opengis.net/wps/2.0.0"
+<schema
+	xmlns="http://www.w3.org/2001/XMLSchema"
+	xmlns:wps="http://www.opengis.net/wps/2.0"
+	targetNamespace="http://www.opengis.net/wps/2.0"
 	elementFormDefault="qualified"
 	xml:lang="en"
-	version="1.0.0">
+	version="2.0.0">
+	
 	<annotation>
 		<documentation>
-			<description>This XML Schema Document encodes the WPS Delete operation information elements.</description>
-			<copyright>
-				WPS is an OGC Standard.
-				Copyright (c) 2013 Open Geospatial Consortium.
-				To obtain additional rights of use, visit http://www.opengeospatial.org/legal/ .
-			</copyright>
+			WPS is an OGC Standard.
+			Copyright (c) 2015 Open Geospatial Consortium.
+			To obtain additional rights of use, visit http://www.opengeospatial.org/legal/.
 		</documentation>
 	</annotation>
+	
+	<!-- all-components document include (OGC 06-135r11 s#14) -->
+	<include schemaLocation="wps.xsd"/>
 	
 	<!-- === INCLUDES === -->
 	<include schemaLocation="wpsCommon.xsd"/>
@@ -50,6 +43,5 @@
 			</complexContent>
 		</complexType>
 	</element>
-	
 	
 </schema>

--- a/schemas/src/main/resources-original/ogc/wps/2.0/wpsExecute.xsd
+++ b/schemas/src/main/resources-original/ogc/wps/2.0/wpsExecute.xsd
@@ -1,35 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-    OGC LICENSE HEADER
-
-    The official OGC XML schemas can be accessed under http://schemas.opengis.net.
-    Please consider the schema copyright notices: http://www.opengeospatial.org/ogc/document
-    and the OGC Copyright Notice and Disclaimers: http://www.opengeospatial.org/ogc/legal
-    If there are any questions left there is also a copyright FAQ: http://www.opengeospatial.org/ogc/legalfaq
--->
-<schema xmlns="http://www.w3.org/2001/XMLSchema"
+<schema
+	xmlns="http://www.w3.org/2001/XMLSchema"
 	xmlns:ows="http://www.opengis.net/ows/2.0"
-	xmlns:xlink="http://www.w3.org/1999/xlink"
-	xmlns:wps="http://www.opengis.net/wps/2.0.0"
-	targetNamespace="http://www.opengis.net/wps/2.0.0"
+	xmlns:wps="http://www.opengis.net/wps/2.0"
+	targetNamespace="http://www.opengis.net/wps/2.0"
 	elementFormDefault="qualified"
 	xml:lang="en"
-	version="1.0.0">
+	version="2.0.0">
+	
 	<annotation>
-		<appinfo>$Id: wpsExecute.xsd 2014-06-15 $</appinfo>
 		<documentation>
-			<description>This XML Schema Document encodes the WPS Execute operation request.</description>
-			<copyright>
-				WPS is an OGC Standard.
-				Copyright (c) 2014 Open Geospatial Consortium.
-				To obtain additional rights of use, visit http://www.opengeospatial.org/legal/ .
-			</copyright>
+			WPS is an OGC Standard.
+			Copyright (c) 2015 Open Geospatial Consortium.
+			To obtain additional rights of use, visit http://www.opengeospatial.org/legal/.
 		</documentation>
 	</annotation>
 	
+	<!-- all-components document include (OGC 06-135r11 s#14) -->
+	<include schemaLocation="wps.xsd"/>
+	
 	<!-- === IMPORTS === -->
-	<import namespace="http://www.opengis.net/ows/2.0" schemaLocation="http://schemas.opengis.net/ows/2.0/owsCommon.xsd" />
-	<import namespace="http://www.w3.org/1999/xlink" schemaLocation="http://www.w3.org/1999/xlink.xsd"/>
+	<import namespace="http://www.opengis.net/ows/2.0" schemaLocation="http://schemas.opengis.net/ows/2.0/owsAll.xsd" />
 	
 	<!-- === INCLUDES === -->
 	<include schemaLocation="wpsCommon.xsd"/>

--- a/schemas/src/main/resources-original/ogc/wps/2.0/wpsGetCapabilities.xsd
+++ b/schemas/src/main/resources-original/ogc/wps/2.0/wpsGetCapabilities.xsd
@@ -1,34 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-    OGC LICENSE HEADER
-
-    The official OGC XML schemas can be accessed under http://schemas.opengis.net.
-    Please consider the schema copyright notices: http://www.opengeospatial.org/ogc/document
-    and the OGC Copyright Notice and Disclaimers: http://www.opengeospatial.org/ogc/legal
-    If there are any questions left there is also a copyright FAQ: http://www.opengeospatial.org/ogc/legalfaq
--->
-<schema xmlns="http://www.w3.org/2001/XMLSchema"
+<schema
+	xmlns="http://www.w3.org/2001/XMLSchema"
 	xmlns:ows="http://www.opengis.net/ows/2.0"
-	xmlns:wps="http://www.opengis.net/wps/2.0.0"
-	targetNamespace="http://www.opengis.net/wps/2.0.0"
+	xmlns:wps="http://www.opengis.net/wps/2.0"
+	targetNamespace="http://www.opengis.net/wps/2.0"
 	elementFormDefault="qualified"
 	xml:lang="en"
-	version="1.0.0">
+	version="2.0.0">
+	
 	<annotation>
-		<appinfo>$Id: wpsGetCapabilities.xsd 2014-05-20 $</appinfo>
 		<documentation>
-			<description>This XML Schema Document encodes the WPS GetCapabilities operation request.</description>
-			<copyright>
-				WPS is an OGC Standard.
-				Copyright (c) 2014 Open Geospatial Consortium.
-				To obtain additional rights of use, visit http://www.opengeospatial.org/legal/ .
-			</copyright>
+			WPS is an OGC Standard.
+			Copyright (c) 2015 Open Geospatial Consortium.
+			To obtain additional rights of use, visit http://www.opengeospatial.org/legal/.
 		</documentation>
 	</annotation>
 	
+	<!-- all-components document include (OGC 06-135r11 s#14) -->
+	<include schemaLocation="wps.xsd"/>
+	
 	<!-- === IMPORTS === -->
-	<import namespace="http://www.opengis.net/ows/2.0" schemaLocation="http://schemas.opengis.net/ows/2.0/owsCommon.xsd" />
-	<import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="http://www.w3.org/2001/xml.xsd"/>
+	<import namespace="http://www.opengis.net/ows/2.0" schemaLocation="http://schemas.opengis.net/ows/2.0/owsAll.xsd" />
 	
 	<!-- === INCLUDES === -->
 	<include schemaLocation="wpsCommon.xsd"/>

--- a/schemas/src/main/resources-original/ogc/wps/2.0/wpsGetResult.xsd
+++ b/schemas/src/main/resources-original/ogc/wps/2.0/wpsGetResult.xsd
@@ -1,32 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-    OGC LICENSE HEADER
-
-    The official OGC XML schemas can be accessed under http://schemas.opengis.net.
-    Please consider the schema copyright notices: http://www.opengeospatial.org/ogc/document
-    and the OGC Copyright Notice and Disclaimers: http://www.opengeospatial.org/ogc/legal
-    If there are any questions left there is also a copyright FAQ: http://www.opengeospatial.org/ogc/legalfaq
--->
-<schema xmlns="http://www.w3.org/2001/XMLSchema"
-	xmlns:ows="http://www.opengis.net/ows/2.0"
-	xmlns:wps="http://www.opengis.net/wps/2.0.0"
-	targetNamespace="http://www.opengis.net/wps/2.0.0"
+<schema
+	xmlns="http://www.w3.org/2001/XMLSchema"
+	xmlns:wps="http://www.opengis.net/wps/2.0"
+	targetNamespace="http://www.opengis.net/wps/2.0"
 	elementFormDefault="qualified"
 	xml:lang="en"
-	version="1.0.0">
+	version="2.0.0">
+	
 	<annotation>
 		<documentation>
-			<description>This XML Schema Document encodes the WPS GetResult information elements.</description>
-			<copyright>
-				WPS is an OGC Standard.
-				Copyright (c) 2013 Open Geospatial Consortium.
-				To obtain additional rights of use, visit http://www.opengeospatial.org/legal/ .
-			</copyright>
+			WPS is an OGC Standard.
+			Copyright (c) 2015 Open Geospatial Consortium.
+			To obtain additional rights of use, visit http://www.opengeospatial.org/legal/.
 		</documentation>
 	</annotation>
 	
-	<!-- === IMPORTS === -->
-	<import namespace="http://www.opengis.net/ows/2.0" schemaLocation="http://schemas.opengis.net/ows/2.0/owsCommon.xsd" />
+	<!-- all-components document include (OGC 06-135r11 s#14) -->
+	<include schemaLocation="wps.xsd"/>
 	
 	<!-- === INCLUDES === -->
 	<include schemaLocation="wpsCommon.xsd"/>

--- a/schemas/src/main/resources-original/ogc/wps/2.0/wpsGetStatus.xsd
+++ b/schemas/src/main/resources-original/ogc/wps/2.0/wpsGetStatus.xsd
@@ -1,29 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-    OGC LICENSE HEADER
-
-    The official OGC XML schemas can be accessed under http://schemas.opengis.net.
-    Please consider the schema copyright notices: http://www.opengeospatial.org/ogc/document
-    and the OGC Copyright Notice and Disclaimers: http://www.opengeospatial.org/ogc/legal
-    If there are any questions left there is also a copyright FAQ: http://www.opengeospatial.org/ogc/legalfaq
--->
-<schema xmlns="http://www.w3.org/2001/XMLSchema"
-	xmlns:ows="http://www.opengis.net/ows/2.0"
-	xmlns:wps="http://www.opengis.net/wps/2.0.0"
-	targetNamespace="http://www.opengis.net/wps/2.0.0"
+<schema
+	xmlns="http://www.w3.org/2001/XMLSchema"
+	xmlns:wps="http://www.opengis.net/wps/2.0"
+	targetNamespace="http://www.opengis.net/wps/2.0"
 	elementFormDefault="qualified"
 	xml:lang="en"
-	version="1.0.0">
+	version="2.0.0">
+	
 	<annotation>
 		<documentation>
-			<description>This XML Schema Document encodes the WPS StatusInfo information elements.</description>
-			<copyright>
-				WPS is an OGC Standard.
-				Copyright (c) 2013 Open Geospatial Consortium.
-				To obtain additional rights of use, visit http://www.opengeospatial.org/legal/ .
-			</copyright>
+			WPS is an OGC Standard.
+			Copyright (c) 2015 Open Geospatial Consortium.
+			To obtain additional rights of use, visit http://www.opengeospatial.org/legal/.
 		</documentation>
 	</annotation>
+	
+	<!-- all-components document include (OGC 06-135r11 s#14) -->
+	<include schemaLocation="wps.xsd"/>
 	
 	<!-- === INCLUDES === -->
 	<include schemaLocation="wpsCommon.xsd"/>
@@ -50,6 +43,5 @@
 			</complexContent>
 		</complexType>
 	</element>
-	
 	
 </schema>

--- a/schemas/src/main/resources-original/ogc/wps/2.0/xml-examples/profile-examples/Planar-GML-Buffer.xml
+++ b/schemas/src/main/resources-original/ogc/wps/2.0/xml-examples/profile-examples/Planar-GML-Buffer.xml
@@ -1,20 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-    OGC LICENSE HEADER
-
-    The official OGC XML schemas can be accessed under http://schemas.opengis.net.
-    Please consider the schema copyright notices: http://www.opengeospatial.org/ogc/document
-    and the OGC Copyright Notice and Disclaimers: http://www.opengeospatial.org/ogc/legal
-    If there are any questions left there is also a copyright FAQ: http://www.opengeospatial.org/ogc/legalfaq
--->
-<!--This example describes a buffer command that accepts geometries 
-	in GML, and uses a buffer distance in meters to produce buffered polygon 
-	features, which is output in GML in UTF-8 encoding. -->
-<wps:Process xmlns:wps="http://www.opengis.net/wps/2.0.0"
+<wps:Process
+	xmlns:wps="http://www.opengis.net/wps/2.0"
 	xmlns:ows="http://www.opengis.net/ows/2.0"
 	xmlns:xlink="http://www.w3.org/1999/xlink"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.opengis.net/wps/2.0.0 ../../wps.xsd">
+	xsi:schemaLocation="http://www.opengis.net/wps/2.0 ../../wps.xsd">
 	
 	<ows:Title>Planar Buffer operation for GML features</ows:Title>
 	<ows:Abstract>Create a buffer around a GML feature. Accepts any valid GML feature and computes the joint buffer.</ows:Abstract>
@@ -43,8 +33,8 @@
 			<LiteralDataDomain default="true">
 				<ows:AllowedValues>
 					<ows:Range>
-						<ows:MinimumValue>1</ows:MinimumValue>
-						<ows:MaximumValue>unbounded</ows:MaximumValue>
+						<ows:MinimumValue>-INF</ows:MinimumValue>
+						<ows:MaximumValue>INF</ows:MaximumValue>
 					</ows:Range>
 				</ows:AllowedValues>
 				<ows:DataType ows:reference="http://www.w3.org/2001/XMLSchema#double">Double</ows:DataType>
@@ -60,4 +50,5 @@
 			<wps:Format mimeType="text/xml" encoding="UTF-8" schema="http://schemas.opengis.net/gml/3.2.1/feature.xsd" default="true"/>
 		</wps:ComplexData>
 	</wps:Output>
+	
 </wps:Process>

--- a/schemas/src/main/resources-original/ogc/wps/2.0/xml-examples/profile-examples/SimpleFeaturesBuffer.xml
+++ b/schemas/src/main/resources-original/ogc/wps/2.0/xml-examples/profile-examples/SimpleFeaturesBuffer.xml
@@ -1,17 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-    OGC LICENSE HEADER
-
-    The official OGC XML schemas can be accessed under http://schemas.opengis.net.
-    Please consider the schema copyright notices: http://www.opengeospatial.org/ogc/document
-    and the OGC Copyright Notice and Disclaimers: http://www.opengeospatial.org/ogc/legal
-    If there are any questions left there is also a copyright FAQ: http://www.opengeospatial.org/ogc/legalfaq
--->
 <wps:GenericProcess
-	xmlns:ows="http://www.opengis.net/ows/2.0" xmlns:wps="http://www.opengis.net/wps/2.0.0"
-	xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xml="http://www.w3.org/XML/1998/namespace"
+	xmlns:ows="http://www.opengis.net/ows/2.0"
+	xmlns:wps="http://www.opengis.net/wps/2.0"
+	xmlns:xlink="http://www.w3.org/1999/xlink"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.opengis.net/wps/2.0.0 ../../processProfile.xsd">
+	xsi:schemaLocation="http://www.opengis.net/wps/2.0 ../../wps.xsd">
+	
 	<ows:Title>Simple Features Buffer</ows:Title>
 	<ows:Identifier>http://some.host/profileregistry/generic/SF-Buffer</ows:Identifier>
 	<ows:Metadata xlink:role="http://www.opengis.net/spec/wps/2.0/def/process-profile/concept" xlink:href="http://some.host/profileregistry/concept/buffer"/>

--- a/schemas/src/main/resources-original/ogc/wps/2.0/xml-examples/profile-examples/SimpleFeaturesBufferWithTolerance.xml
+++ b/schemas/src/main/resources-original/ogc/wps/2.0/xml-examples/profile-examples/SimpleFeaturesBufferWithTolerance.xml
@@ -1,17 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-    OGC LICENSE HEADER
-
-    The official OGC XML schemas can be accessed under http://schemas.opengis.net.
-    Please consider the schema copyright notices: http://www.opengeospatial.org/ogc/document
-    and the OGC Copyright Notice and Disclaimers: http://www.opengeospatial.org/ogc/legal
-    If there are any questions left there is also a copyright FAQ: http://www.opengeospatial.org/ogc/legalfaq
--->
 <wps:GenericProcess
-	xmlns:ows="http://www.opengis.net/ows/2.0" xmlns:wps="http://www.opengis.net/wps/2.0.0"
-	xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xml="http://www.w3.org/XML/1998/namespace"
+	xmlns:ows="http://www.opengis.net/ows/2.0"
+	xmlns:wps="http://www.opengis.net/wps/2.0"
+	xmlns:xlink="http://www.w3.org/1999/xlink"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.opengis.net/wps/2.0.0 ../../processProfile.xsd">
+	xsi:schemaLocation="http://www.opengis.net/wps/2.0 ../../wps.xsd">
+	
 	<ows:Title>Simple Features Buffer</ows:Title>
 	<ows:Identifier>http://some.host/profileregistry/generic/SF-Buffer-With-Tolerance</ows:Identifier>
 	<ows:Metadata xlink:role="http://www.opengis.net/spec/wps/2.0/def/process-profile/concept" xlink:href="http://some.host/profileregistry/concept/buffer"/>

--- a/schemas/src/main/resources-original/ogc/wps/2.0/xml-examples/profile-examples/SimpleGeodesicFeaturesBuffer.xml
+++ b/schemas/src/main/resources-original/ogc/wps/2.0/xml-examples/profile-examples/SimpleGeodesicFeaturesBuffer.xml
@@ -1,17 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-    OGC LICENSE HEADER
-
-    The official OGC XML schemas can be accessed under http://schemas.opengis.net.
-    Please consider the schema copyright notices: http://www.opengeospatial.org/ogc/document
-    and the OGC Copyright Notice and Disclaimers: http://www.opengeospatial.org/ogc/legal
-    If there are any questions left there is also a copyright FAQ: http://www.opengeospatial.org/ogc/legalfaq
--->
 <wps:GenericProcess
-	xmlns:ows="http://www.opengis.net/ows/2.0" xmlns:wps="http://www.opengis.net/wps/2.0.0"
-	xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xml="http://www.w3.org/XML/1998/namespace"
+	xmlns:ows="http://www.opengis.net/ows/2.0"
+	xmlns:wps="http://www.opengis.net/wps/2.0"
+	xmlns:xlink="http://www.w3.org/1999/xlink"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.opengis.net/wps/2.0.0 ../../processProfile.xsd">
+	xsi:schemaLocation="http://www.opengis.net/wps/2.0 ../../wps.xsd">
+	
 	<ows:Title>Simple Geodesic Features Buffer</ows:Title>
 	<ows:Identifier>http://some.host/profileregistry/generic/SimpleGeodesicFeaturesBuffer</ows:Identifier>
 	<ows:Metadata xlink:role="http://www.opengis.net/spec/wps/2.0/def/process-profile/concept" xlink:href="http://some.host/profileregistry/concept/buffer"/>

--- a/schemas/src/main/resources-original/ogc/wps/2.0/xml-examples/wpsCapabilitiesDocumentExample.xml
+++ b/schemas/src/main/resources-original/ogc/wps/2.0/xml-examples/wpsCapabilitiesDocumentExample.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wps:Capabilities
+	xmlns:ows="http://www.opengis.net/ows/2.0"
+	xmlns:wps="http://www.opengis.net/wps/2.0"
+	xmlns:xlink="http://www.w3.org/1999/xlink"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.opengis.net/wps/2.0 ../wps.xsd"
+	
+	service="WPS"
+	version="2.0.0">
+	
+	<ows:ServiceIdentification>
+		<ows:Title>MyWebProcessingService</ows:Title>
+		<ows:Abstract>A Demo Service offering typical GIS distance transform processes</ows:Abstract>
+		<ows:Keywords>
+			<ows:Keyword>Geoprocessing</ows:Keyword>
+			<ows:Keyword>Toolbox</ows:Keyword>
+			<ows:Keyword>Distance transform</ows:Keyword>
+		</ows:Keywords>
+		<ows:ServiceType>WPS</ows:ServiceType>
+		<ows:ServiceTypeVersion>2.0.0</ows:ServiceTypeVersion>
+		<ows:Fees>NONE</ows:Fees>
+		<ows:AccessConstraints>NONE</ows:AccessConstraints>
+	</ows:ServiceIdentification>
+	<ows:ServiceProvider>
+		<ows:ProviderName>TU Dresden</ows:ProviderName>
+		<ows:ProviderSite xlink:href="http://tu-dresden.de/geo/gis" />
+		<ows:ServiceContact>
+			<ows:IndividualName>Matthias Mueller</ows:IndividualName>
+			<ows:ContactInfo>
+				<ows:Address>
+					<ows:ElectronicMailAddress>
+						matthias_mueller@tu-dresden.de
+					</ows:ElectronicMailAddress>
+				</ows:Address>
+			</ows:ContactInfo>
+		</ows:ServiceContact>
+	</ows:ServiceProvider>
+	<ows:OperationsMetadata>
+		<ows:Operation name="GetCapabilities">
+			<ows:DCP>
+				<ows:HTTP>
+					<ows:Get 
+					xlink:href="http://wps1.gis.geo.tu-dresden.de/wps"/>
+				</ows:HTTP>
+			</ows:DCP>
+		</ows:Operation>
+		<ows:Operation name="DescribeProcess">
+			<ows:DCP>
+				<ows:HTTP>
+					<ows:Get 
+					xlink:href="http://wps1.gis.geo.tu-dresden.de/wps"/>
+					<ows:Post 
+					xlink:href="http://wps1.gis.geo.tu-dresden.de/wps"/>
+				</ows:HTTP>
+			</ows:DCP>
+		</ows:Operation>
+		<ows:Operation name="Execute">
+			<ows:DCP>
+				<ows:HTTP>
+					<ows:Post 
+					xlink:href="http://wps1.gis.geo.tu-dresden.de/wps"/>
+				</ows:HTTP>
+			</ows:DCP>
+		</ows:Operation>
+		<ows:Operation name="GetStatus">
+			<ows:DCP>
+				<ows:HTTP>
+					<ows:Get 
+					xlink:href="http://wps1.gis.geo.tu-dresden.de/wps"/>
+					<ows:Post 
+					xlink:href="http://wps1.gis.geo.tu-dresden.de/wps"/>
+				</ows:HTTP>
+			</ows:DCP>
+		</ows:Operation>
+		<ows:Operation name="GetResult">
+			<ows:DCP>
+				<ows:HTTP>
+					<ows:Get 
+					xlink:href="http://wps1.gis.geo.tu-dresden.de/wps"/>
+					<ows:Post 
+					xlink:href="http://wps1.gis.geo.tu-dresden.de/wps"/>
+				</ows:HTTP>
+			</ows:DCP>
+		</ows:Operation>
+		<ows:Operation name="Dismiss">
+			<ows:DCP>
+				<ows:HTTP>
+					<ows:Get 
+					xlink:href="http://wps1.gis.geo.tu-dresden.de/wps"/>
+					<ows:Post 
+					xlink:href="http://wps1.gis.geo.tu-dresden.de/wps"/>
+				</ows:HTTP>
+			</ows:DCP>
+		</ows:Operation>
+	</ows:OperationsMetadata>
+	<wps:Contents>
+		<wps:ProcessSummary jobControlOptions="sync-execute async-execute dismiss">
+			<ows:Title>Euclidean Distance</ows:Title>
+			<ows:Identifier>http://my.site/distance-transform/euclidean-distance</ows:Identifier>
+		</wps:ProcessSummary>
+		<wps:ProcessSummary jobControlOptions="sync-execute async-execute dismiss"
+			processVersion="1.4.0">
+			<ows:Title>Cost Distance</ows:Title>
+			<ows:Identifier>http://my.site/distance-transform/cost-distance</ows:Identifier>
+		</wps:ProcessSummary>
+	</wps:Contents>
+	
+</wps:Capabilities>

--- a/schemas/src/main/resources-original/ogc/wps/2.0/xml-examples/wpsDescribeProcessRequestExample.xml
+++ b/schemas/src/main/resources-original/ogc/wps/2.0/xml-examples/wpsDescribeProcessRequestExample.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<wps:GetResult 
+<wps:DescribeProcess
+	xmlns:ows="http://www.opengis.net/ows/2.0"
 	xmlns:wps="http://www.opengis.net/wps/2.0"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.opengis.net/wps/2.0 ../wps.xsd"
@@ -7,6 +8,7 @@
 	service="WPS"
 	version="2.0.0">
 	
-	<wps:JobID>FB6DD4B0-A2BB-11E3-A5E2-0800200C9A66</wps:JobID>
+	<ows:Identifier>Buffer</ows:Identifier>
+	<ows:Identifier>Viewshed</ows:Identifier>
 	
-</wps:GetResult>
+</wps:DescribeProcess>

--- a/schemas/src/main/resources-original/ogc/wps/2.0/xml-examples/wpsDismissRequestExample.xml
+++ b/schemas/src/main/resources-original/ogc/wps/2.0/xml-examples/wpsDismissRequestExample.xml
@@ -1,15 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-    OGC LICENSE HEADER
-
-    The official OGC XML schemas can be accessed under http://schemas.opengis.net.
-    Please consider the schema copyright notices: http://www.opengeospatial.org/ogc/document
-    and the OGC Copyright Notice and Disclaimers: http://www.opengeospatial.org/ogc/legal
-    If there are any questions left there is also a copyright FAQ: http://www.opengeospatial.org/ogc/legalfaq
--->
-<wps:Dismiss service="WPS" version="2.0.0"
-	xmlns:wps="http://www.opengis.net/wps/2.0.0"
+<wps:Dismiss
+	xmlns:wps="http://www.opengis.net/wps/2.0"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.opengis.net/wps/2.0.0 ../wpsDismiss.xsd ">
+	xsi:schemaLocation="http://www.opengis.net/wps/2.0 ../wps.xsd"
+	
+	service="WPS"
+	version="2.0.0">
+	
 	<wps:JobID>FB6DD4B0-A2BB-11E3-A5E2-0800200C9A66</wps:JobID>
+	
 </wps:Dismiss>

--- a/schemas/src/main/resources-original/ogc/wps/2.0/xml-examples/wpsExecuteRequestExample.xml
+++ b/schemas/src/main/resources-original/ogc/wps/2.0/xml-examples/wpsExecuteRequestExample.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wps:Execute
+	xmlns:wps="http://www.opengis.net/wps/2.0"
+	xmlns:ows="http://www.opengis.net/ows/2.0"
+	xmlns:xlink="http://www.w3.org/1999/xlink"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.opengis.net/wps/2.0 ../wps.xsd"
+	
+	service="WPS"
+	version="2.0.0"
+	response="document"
+	mode="async">
+	
+	<ows:Identifier>http://my.wps.server/processes/proximity/Planar-Buffer</ows:Identifier>
+	<wps:Input id="INPUT_GEOMETRY">
+		<wps:Reference xlink:href="http://some.data.server/mygmldata.xml"/>
+	</wps:Input>
+	<wps:Input id="DISTANCE">
+		<wps:Data>10.0</wps:Data>
+	</wps:Input>
+	
+	<!-- Query the default output format for the the result "BUFFERED_GEOMETRY" -->
+	<!-- The result "BUFFERED_GEOMETRY" shall be delivered by reference in its default format -->
+	<wps:Output id="BUFFERED_GEOMETRY" transmission="reference"/>
+	
+</wps:Execute>

--- a/schemas/src/main/resources-original/ogc/wps/2.0/xml-examples/wpsGetCapabilitiesRequestExample.xml
+++ b/schemas/src/main/resources-original/ogc/wps/2.0/xml-examples/wpsGetCapabilitiesRequestExample.xml
@@ -1,15 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-    OGC LICENSE HEADER
-
-    The official OGC XML schemas can be accessed under http://schemas.opengis.net.
-    Please consider the schema copyright notices: http://www.opengeospatial.org/ogc/document
-    and the OGC Copyright Notice and Disclaimers: http://www.opengeospatial.org/ogc/legal
-    If there are any questions left there is also a copyright FAQ: http://www.opengeospatial.org/ogc/legalfaq
--->
-<wps:GetCapabilities service="WPS"
-	xmlns:ows="http://www.opengis.net/ows/2.0"
-	xmlns:wps="http://www.opengis.net/wps/2.0.0"
+<wps:GetCapabilities
+	xmlns:wps="http://www.opengis.net/wps/2.0"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.opengis.net/wps/2.0.0 ../wpsGetCapabilities.xsd ">
+	xsi:schemaLocation="http://www.opengis.net/wps/2.0 ../wps.xsd"
+	
+	service="WPS">
+	
 </wps:GetCapabilities>

--- a/schemas/src/main/resources-original/ogc/wps/2.0/xml-examples/wpsGetStatusRequestExample.xml
+++ b/schemas/src/main/resources-original/ogc/wps/2.0/xml-examples/wpsGetStatusRequestExample.xml
@@ -1,15 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-    OGC LICENSE HEADER
-
-    The official OGC XML schemas can be accessed under http://schemas.opengis.net.
-    Please consider the schema copyright notices: http://www.opengeospatial.org/ogc/document
-    and the OGC Copyright Notice and Disclaimers: http://www.opengeospatial.org/ogc/legal
-    If there are any questions left there is also a copyright FAQ: http://www.opengeospatial.org/ogc/legalfaq
--->
-<wps:GetStatus service="WPS" version="2.0.0"
-	xmlns:wps="http://www.opengis.net/wps/2.0.0"
+<wps:GetStatus
+	xmlns:wps="http://www.opengis.net/wps/2.0"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.opengis.net/wps/2.0.0 ../wpsGetStatus.xsd ">
+	xsi:schemaLocation="http://www.opengis.net/wps/2.0 ../wps.xsd"
+	
+	service="WPS"
+	version="2.0.0">
+	
 	<wps:JobID>FB6DD4B0-A2BB-11E3-A5E2-0800200C9A66</wps:JobID>
+	
 </wps:GetStatus>

--- a/schemas/src/main/resources-original/ogc/wps/2.0/xml-examples/wpsProcessOfferingsExample.xml
+++ b/schemas/src/main/resources-original/ogc/wps/2.0/xml-examples/wpsProcessOfferingsExample.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wps:ProcessOfferings
+	xmlns:wps="http://www.opengis.net/wps/2.0"
+	xmlns:ows="http://www.opengis.net/ows/2.0"
+	xmlns:xlink="http://www.w3.org/1999/xlink"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.opengis.net/wps/2.0 ../wps.xsd">
+	
+	<wps:ProcessOffering jobControlOptions="sync-execute async-execute dismiss" outputTransmission="value reference">
+		<wps:Process> 			
+			<ows:Title>Planar Buffer operation for Simple Features</ows:Title>
+			<ows:Abstract>Create a buffer around Simple Feature geometries. Accepts any valid simple features input in GML or GeoJson and computes their joint buffer geometry.</ows:Abstract>
+			<ows:Identifier>http://my.wps.server/processes/proximity/Planar-Buffer</ows:Identifier>
+			<ows:Metadata xlink:role="http://www.opengis.net/spec/wps/2.0/def/process-profile/concept" xlink:href="http://some.host/profileregistry/concept/buffer"/>
+			<ows:Metadata xlink:role="http://www.opengis.net/spec/wps/2.0/def/process-profile/concept" xlink:href="http://some.host/profileregistry/concept/planarbuffer"/>
+			<ows:Metadata xlink:role="http://www.opengis.net/spec/wps/2.0/def/process-profile/generic" xlink:href="http://some.host/profileregistry/generic/SF-Buffer"/>
+			<ows:Metadata xlink:role="http://www.opengis.net/spec/wps/2.0/def/process/description/documentation" xlink:href="http://some.host/profileregistry/implementation/Planar-GML-Buffer.html"/>
+			<wps:Input>
+				<ows:Title>Geometry to be buffered</ows:Title>
+				<ows:Abstract>Simple Features geometry input in GML or GeoJson</ows:Abstract>
+				<ows:Identifier>INPUT_GEOMETRY</ows:Identifier>
+				<ows:Metadata xlink:role="http://www.opengis.net/spec/wps/2.0/def/process/description/documentation" xlink:href="http://my.wps.server/processes/proximity/Planar-Buffer.html#input_geometry"/>
+				<wps:ComplexData>
+					<wps:Format mimeType="text/xml" encoding="UTF-8" schema="http://schemas.opengis.net/gml/3.2.1/feature.xsd" default="true"/>
+					<wps:Format mimeType="application/json" encoding="UTF-8"/>
+				</wps:ComplexData>
+			</wps:Input>
+			<wps:Input minOccurs="0">
+				<ows:Title>Distance</ows:Title>
+				<ows:Abstract>Distance to be used to calculate buffer.</ows:Abstract>
+				<ows:Identifier>DISTANCE</ows:Identifier>
+				<ows:Metadata xlink:role="http://www.opengis.net/spec/wps/2.0/def/process/description/documentation" xlink:href="http://my.wps.server/processes/proximity/Planar-Buffer.html#distance"/>
+				<wps:LiteralData>
+					<wps:Format mimeType="text/plain" default="true"/>
+					<wps:Format mimeType="text/xml"/>
+					<LiteralDataDomain default="true">
+						<ows:AllowedValues>
+							<ows:Range>
+								<ows:MinimumValue>-INF</ows:MinimumValue>
+								<ows:MaximumValue>INF</ows:MaximumValue>
+							</ows:Range>
+						</ows:AllowedValues>
+						<ows:DataType ows:reference="http://www.w3.org/2001/XMLSchema#double">Double</ows:DataType>
+					</LiteralDataDomain>
+				</wps:LiteralData>
+			</wps:Input>
+			<wps:Output>
+				<ows:Title>Buffered Geometry</ows:Title>
+				<ows:Abstract>Output Geometry in GML or GeoJson</ows:Abstract>
+				<ows:Identifier>BUFFERED_GEOMETRY</ows:Identifier>
+				<ows:Metadata xlink:role="http://www.opengis.net/spec/wps/2.0/def/process/description/documentation" xlink:href="http://my.wps.server/processes/proximity/Planar-Buffer.html#buffered_geometry"/>
+				<wps:ComplexData>
+					<wps:Format mimeType="text/xml" encoding="UTF-8" schema="http://schemas.opengis.net/gml/3.2.1/feature.xsd" default="true"/>
+					<wps:Format mimeType="application/json" encoding="UTF-8"/>
+				</wps:ComplexData>
+			</wps:Output>
+		</wps:Process>
+	</wps:ProcessOffering>
+	
+</wps:ProcessOfferings>

--- a/schemas/src/main/resources-original/ogc/wps/2.0/xml-examples/wpsResultExample.xml
+++ b/schemas/src/main/resources-original/ogc/wps/2.0/xml-examples/wpsResultExample.xml
@@ -1,21 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-    OGC LICENSE HEADER
-
-    The official OGC XML schemas can be accessed under http://schemas.opengis.net.
-    Please consider the schema copyright notices: http://www.opengeospatial.org/ogc/document
-    and the OGC Copyright Notice and Disclaimers: http://www.opengeospatial.org/ogc/legal
-    If there are any questions left there is also a copyright FAQ: http://www.opengeospatial.org/ogc/legalfaq
--->
-<wps:Result xmlns:ows="http://www.opengis.net/ows/2.0"
-	xmlns:wps="http://www.opengis.net/wps/2.0.0"
+<wps:Result
+	xmlns:wps="http://www.opengis.net/wps/2.0"
 	xmlns:xlink="http://www.w3.org/1999/xlink"
-	xmlns:xml="http://www.w3.org/XML/1998/namespace"
-	xmlns:xs="http://www.w3.org/2001/XMLSchema"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.opengis.net/wps/2.0.0 ../wpsGetResult.xsd ">
+	xsi:schemaLocation="http://www.opengis.net/wps/2.0 ../wps.xsd ">
+	
 	<wps:JobID>FB6DD4B0-A2BB-11E3-A5E2-0800200C9A66</wps:JobID>
-	<wps:Output id="some_id">
-		<wps:Reference xlink:href="http://tempuri.org/foobar" />
+	<wps:ExpirationDate>2014-12-24T24:00:00Z</wps:ExpirationDate>
+	<wps:Output id="BUFFERED_GEOMETRY">
+		<wps:Reference xlink:href="http://result.data.server/FB6DD4B0-A2BB-11E3-A5E2-0800200C9A66/BUFFERED_GEOMETRY.xml"/>
 	</wps:Output>
+	
 </wps:Result>

--- a/schemas/src/main/resources-original/ogc/wps/2.0/xml-examples/wpsStatusInfoExample.xml
+++ b/schemas/src/main/resources-original/ogc/wps/2.0/xml-examples/wpsStatusInfoExample.xml
@@ -1,17 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-    OGC LICENSE HEADER
-
-    The official OGC XML schemas can be accessed under http://schemas.opengis.net.
-    Please consider the schema copyright notices: http://www.opengeospatial.org/ogc/document
-    and the OGC Copyright Notice and Disclaimers: http://www.opengeospatial.org/ogc/legal
-    If there are any questions left there is also a copyright FAQ: http://www.opengeospatial.org/ogc/legalfaq
--->
-<wps:StatusInfo xmlns:ows="http://www.opengis.net/ows/2.0"
-	xmlns:wps="http://www.opengis.net/wps/2.0.0"
+<wps:StatusInfo
+	xmlns:wps="http://www.opengis.net/wps/2.0"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.opengis.net/wps/2.0.0 ../wpsCommon.xsd">
+	xsi:schemaLocation="http://www.opengis.net/wps/2.0 ../wps.xsd">
+	
 	<wps:JobID>FB6DD4B0-A2BB-11E3-A5E2-0800200C9A66</wps:JobID>
 	<wps:Status>Accepted</wps:Status>
 	<wps:NextPoll>2014-12-24T16:00:00Z</wps:NextPoll>
+	
 </wps:StatusInfo>


### PR DESCRIPTION
I updated the schemas to the ones the OGC put online a few days ago.  The changes I observed were:
* Import rework.
* Improved documentation.
* Corrected the schema version number.