### PR TITLE
Issue #111, fixes to be able to unmarshall a PropertyNameType

### DIFF
--- a/filter/1.0.0/src/test/java/net/opengis/filter/v_1_0_0/tests/Filter_Test.java
+++ b/filter/1.0.0/src/test/java/net/opengis/filter/v_1_0_0/tests/Filter_Test.java
@@ -3,6 +3,7 @@ package net.opengis.filter.v_1_0_0.tests;
 import java.io.StringReader;
 
 import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBElement;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Unmarshaller;
 
@@ -49,7 +50,7 @@ public class Filter_Test {
 				+ "</ogc:Filter>";
 
 		Unmarshaller unmarshaller = this.context.createUnmarshaller();
-		FilterType filter = (FilterType) unmarshaller.unmarshal(new StringReader(xml));
+		JAXBElement<FilterType> filter = (JAXBElement<FilterType>) unmarshaller.unmarshal(new StringReader(xml));
 		Assert.assertNotNull(filter);
 	}
 

--- a/filter/1.0.0/src/test/java/net/opengis/filter/v_1_0_0/tests/Filter_Test.java
+++ b/filter/1.0.0/src/test/java/net/opengis/filter/v_1_0_0/tests/Filter_Test.java
@@ -1,0 +1,56 @@
+package net.opengis.filter.v_1_0_0.tests;
+
+import java.io.StringReader;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Unmarshaller;
+
+import net.opengis.filter.v_1_0_0.FilterType;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests for the FilterType class.
+ */
+public class Filter_Test {
+
+	/**
+	 * Holder of the context
+	 */
+	private JAXBContext context;
+
+	@Before
+	public void initializeContext() throws JAXBException {
+		this.context = JAXBContext.newInstance(FilterType.class.getPackage()
+				.getName()
+				+ ":"
+				+ FilterType.class.getPackage().getName());
+	}
+
+	/**
+	 * Verifies that a PropertyNameType object can be unmarshalled.
+	 * 
+	 * @throws Exception
+	 *             Thrown if there is a problem.
+	 */
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testUnmarshallPropertyNameType() throws Exception {
+		
+		String xml = "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
+				+ "<ogc:Filter xmlns:ogc=\"http://www.opengis.net/ogc\">"
+				+ "<ogc:PropertyIsEqualTo>"
+				+ "<ogc:PropertyName>someProperty</ogc:PropertyName>"
+				+ "<ogc:Literal>someValue</ogc:Literal>"
+				+ "</ogc:PropertyIsEqualTo>"
+				+ "</ogc:Filter>";
+
+		Unmarshaller unmarshaller = this.context.createUnmarshaller();
+		FilterType filter = (FilterType) unmarshaller.unmarshal(new StringReader(xml));
+		Assert.assertNotNull(filter);
+	}
+
+}

--- a/filter/1.1.0/src/test/java/net/opengis/filter/v_1_1_0/tests/Filter_Test.java
+++ b/filter/1.1.0/src/test/java/net/opengis/filter/v_1_1_0/tests/Filter_Test.java
@@ -3,6 +3,7 @@ package net.opengis.filter.v_1_1_0.tests;
 import java.io.StringReader;
 
 import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBElement;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Unmarshaller;
 
@@ -49,7 +50,7 @@ public class Filter_Test {
 				+ "</ogc:Filter>";
 
 		Unmarshaller unmarshaller = this.context.createUnmarshaller();
-		FilterType filter = (FilterType) unmarshaller.unmarshal(new StringReader(xml));
+		JAXBElement<FilterType> filter = (JAXBElement<FilterType>) unmarshaller.unmarshal(new StringReader(xml));
 		Assert.assertNotNull(filter);
 	}
 

--- a/filter/1.1.0/src/test/java/net/opengis/filter/v_1_1_0/tests/Filter_Test.java
+++ b/filter/1.1.0/src/test/java/net/opengis/filter/v_1_1_0/tests/Filter_Test.java
@@ -1,0 +1,56 @@
+package net.opengis.filter.v_1_1_0.tests;
+
+import java.io.StringReader;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Unmarshaller;
+
+import net.opengis.filter.v_1_1_0.FilterType;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests for the FilterType class.
+ */
+public class Filter_Test {
+
+	/**
+	 * Holder of the context
+	 */
+	private JAXBContext context;
+
+	@Before
+	public void initializeContext() throws JAXBException {
+		this.context = JAXBContext.newInstance(FilterType.class.getPackage()
+				.getName()
+				+ ":"
+				+ FilterType.class.getPackage().getName());
+	}
+
+	/**
+	 * Verifies that a PropertyNameType object can be unmarshalled.
+	 * 
+	 * @throws Exception
+	 *             Thrown if there is a problem.
+	 */
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testUnmarshallPropertyNameType() throws Exception {
+		
+		String xml = "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
+				+ "<ogc:Filter xmlns:ogc=\"http://www.opengis.net/ogc\">"
+				+ "<ogc:PropertyIsEqualTo>"
+				+ "<ogc:PropertyName>someProperty</ogc:PropertyName>"
+				+ "<ogc:Literal>someValue</ogc:Literal>"
+				+ "</ogc:PropertyIsEqualTo>"
+				+ "</ogc:Filter>";
+
+		Unmarshaller unmarshaller = this.context.createUnmarshaller();
+		FilterType filter = (FilterType) unmarshaller.unmarshal(new StringReader(xml));
+		Assert.assertNotNull(filter);
+	}
+
+}

--- a/schemas/src/main/patches/ogc.patch
+++ b/schemas/src/main/patches/ogc.patch
@@ -89,3 +89,33 @@ diff -urN ../resources-original/ogc/wcs/1.0.0/wcsCapabilities.xsd ogc/wcs/1.0.0/
              </xs:restriction>
          </xs:complexContent>
      </xs:complexType>
+--- ../resources-original/ogc/filter/1.0.0/expr.xsd	Sat Jul 21 21:59:38 2012
++++ ogc/filter/1.0.0/expr.xsd	Wed Sep  9 09:42:41 2015
+@@ -68,7 +68,11 @@
+   </xsd:complexType>
+   <xsd:complexType name="PropertyNameType">
+     <xsd:complexContent mixed="true">
+-      <xsd:extension base="ogc:ExpressionType"/>
++      <xsd:extension base="ogc:ExpressionType">
++        <xsd:sequence>
++          <xsd:any minOccurs="0"/>
++        </xsd:sequence>
++      </xsd:extension>
+     </xsd:complexContent>
+   </xsd:complexType>
+ </xsd:schema>
+--- ../resources-original/ogc/filter/1.1.0/expr.xsd	Sat Jul 21 21:59:38 2012
++++ ogc/filter/1.1.0/expr.xsd	Wed Sep  9 09:43:50 2015
+@@ -61,7 +61,11 @@
+    </xsd:complexType>
+    <xsd:complexType name="PropertyNameType">
+       <xsd:complexContent mixed="true">
+-         <xsd:extension base="ogc:ExpressionType"/>
++        <xsd:extension base="ogc:ExpressionType">
++          <xsd:sequence>
++            <xsd:any minOccurs="0"/>
++          </xsd:sequence>
++        </xsd:extension>
+       </xsd:complexContent>
+    </xsd:complexType>
+ </xsd:schema>


### PR DESCRIPTION
As requested, here are the tests along with the previous patched behaviour.