### PR TITLE
Force JAXB generate reference properties.

### DIFF
--- a/schemas/src/main/patches/ogc.patch
+++ b/schemas/src/main/patches/ogc.patch
@@ -1,6 +1,6 @@
 diff -urN ../resources-original/ogc/context/1.0.0/collection.xsd ogc/context/1.0.0/collection.xsd
---- ../resources-original/ogc/context/1.0.0/collection.xsd	Sat Jul 21 21:59:38 2012
-+++ ogc/context/1.0.0/collection.xsd	Thu Sep 10 23:50:32 2015
+--- ../resources-original/ogc/context/1.0.0/collection.xsd	Fri Sep 11 11:08:43 2015
++++ ogc/context/1.0.0/collection.xsd	Fri Sep 11 11:09:58 2015
 @@ -8,6 +8,7 @@
  -->
  <xs:schema targetNamespace="http://www.opengis.net/context" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:context="http://www.opengis.net/context" xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" version="1.0.0.2">
@@ -20,8 +20,8 @@ diff -urN ../resources-original/ogc/context/1.0.0/collection.xsd ogc/context/1.0
 +	-->
  </xs:schema>
 diff -urN ../resources-original/ogc/filter/1.0.0/expr.xsd ogc/filter/1.0.0/expr.xsd
---- ../resources-original/ogc/filter/1.0.0/expr.xsd	Sat Jul 21 21:59:38 2012
-+++ ogc/filter/1.0.0/expr.xsd	Thu Sep 10 23:50:32 2015
+--- ../resources-original/ogc/filter/1.0.0/expr.xsd	Fri Sep 11 11:08:48 2015
++++ ogc/filter/1.0.0/expr.xsd	Fri Sep 11 11:10:03 2015
 @@ -68,7 +68,11 @@
    </xsd:complexType>
    <xsd:complexType name="PropertyNameType">
@@ -36,8 +36,8 @@ diff -urN ../resources-original/ogc/filter/1.0.0/expr.xsd ogc/filter/1.0.0/expr.
    </xsd:complexType>
  </xsd:schema>
 diff -urN ../resources-original/ogc/filter/1.1.0/expr.xsd ogc/filter/1.1.0/expr.xsd
---- ../resources-original/ogc/filter/1.1.0/expr.xsd	Sat Jul 21 21:59:38 2012
-+++ ogc/filter/1.1.0/expr.xsd	Thu Sep 10 23:50:32 2015
+--- ../resources-original/ogc/filter/1.1.0/expr.xsd	Fri Sep 11 11:08:48 2015
++++ ogc/filter/1.1.0/expr.xsd	Fri Sep 11 11:10:04 2015
 @@ -61,7 +61,11 @@
     </xsd:complexType>
     <xsd:complexType name="PropertyNameType">
@@ -51,9 +51,21 @@ diff -urN ../resources-original/ogc/filter/1.1.0/expr.xsd ogc/filter/1.1.0/expr.
        </xsd:complexContent>
     </xsd:complexType>
  </xsd:schema>
+diff -urN ../resources-original/ogc/ows/1.1.0/owsContents.xsd ogc/ows/1.1.0/owsContents.xsd
+--- ../resources-original/ogc/ows/1.1.0/owsContents.xsd	Fri Sep 11 11:09:20 2015
++++ ogc/ows/1.1.0/owsContents.xsd	Fri Sep 11 11:11:50 2015
+@@ -84,4 +84,8 @@
+ 		</complexContent>
+ 	</complexType>
+ 	<!-- ===========================================================-->
++	
++	<!-- This is to force JAXB generate reference properties -->
++	<element name="DatasetDescriptionSummaryExtension" type="ows:DatasetDescriptionSummaryBaseType" substitutionGroup="ows:DatasetDescriptionSummary"/>
++	<element name="OtherSourceExtension" type="ows:MetadataType" substitutionGroup="ows:OtherSource"/>
+ </schema>
 diff -urN ../resources-original/ogc/ows/2.0/owsAdditionalParameters.xsd ogc/ows/2.0/owsAdditionalParameters.xsd
---- ../resources-original/ogc/ows/2.0/owsAdditionalParameters.xsd	Sat Jul 21 21:59:38 2012
-+++ ogc/ows/2.0/owsAdditionalParameters.xsd	Thu Sep 10 23:50:32 2015
+--- ../resources-original/ogc/ows/2.0/owsAdditionalParameters.xsd	Fri Sep 11 11:09:21 2015
++++ ogc/ows/2.0/owsAdditionalParameters.xsd	Fri Sep 11 11:10:36 2015
 @@ -53,13 +53,13 @@
    <!-- ========================================================== -->
    <complexType name="AdditionalParametersType">
@@ -71,8 +83,8 @@ diff -urN ../resources-original/ogc/ows/2.0/owsAdditionalParameters.xsd ogc/ows/
    </complexType>
    <!-- ========================================================== -->
 diff -urN ../resources-original/ogc/sweCommon/1.0.0/aggregateTypes.xsd ogc/sweCommon/1.0.0/aggregateTypes.xsd
---- ../resources-original/ogc/sweCommon/1.0.0/aggregateTypes.xsd	Sat Jul 21 21:59:38 2012
-+++ ogc/sweCommon/1.0.0/aggregateTypes.xsd	Thu Sep 10 23:50:32 2015
+--- ../resources-original/ogc/sweCommon/1.0.0/aggregateTypes.xsd	Fri Sep 11 11:09:32 2015
++++ ogc/sweCommon/1.0.0/aggregateTypes.xsd	Fri Sep 11 11:10:48 2015
 @@ -139,7 +139,7 @@
  		<xs:annotation>
  			<xs:documentation>Use to point or include data values inline</xs:documentation>
@@ -83,8 +95,8 @@ diff -urN ../resources-original/ogc/sweCommon/1.0.0/aggregateTypes.xsd ogc/sweCo
  				<xs:attributeGroup ref="gml:AssociationAttributeGroup"/>
  			</xs:extension>
 diff -urN ../resources-original/ogc/sweCommon/1.0.1/aggregateTypes.xsd ogc/sweCommon/1.0.1/aggregateTypes.xsd
---- ../resources-original/ogc/sweCommon/1.0.1/aggregateTypes.xsd	Sat Jul 21 21:59:38 2012
-+++ ogc/sweCommon/1.0.1/aggregateTypes.xsd	Thu Sep 10 23:50:32 2015
+--- ../resources-original/ogc/sweCommon/1.0.1/aggregateTypes.xsd	Fri Sep 11 11:09:33 2015
++++ ogc/sweCommon/1.0.1/aggregateTypes.xsd	Fri Sep 11 11:10:48 2015
 @@ -138,7 +138,7 @@
  		<xs:annotation>
  			<xs:documentation>Use to point or include data values inline</xs:documentation>
@@ -95,8 +107,8 @@ diff -urN ../resources-original/ogc/sweCommon/1.0.1/aggregateTypes.xsd ogc/sweCo
  				<xs:attribute name="recordCount" type="xs:positiveInteger"/>
  				<xs:attributeGroup ref="gml:AssociationAttributeGroup"/>
 diff -urN ../resources-original/ogc/sweCommon/2.0/basic_types.xsd ogc/sweCommon/2.0/basic_types.xsd
---- ../resources-original/ogc/sweCommon/2.0/basic_types.xsd	Sat Jul 21 21:59:38 2012
-+++ ogc/sweCommon/2.0/basic_types.xsd	Thu Sep 10 23:50:32 2015
+--- ../resources-original/ogc/sweCommon/2.0/basic_types.xsd	Fri Sep 11 11:09:33 2015
++++ ogc/sweCommon/2.0/basic_types.xsd	Fri Sep 11 11:10:49 2015
 @@ -78,7 +78,7 @@
  	</complexType>
  	<!-- ================================================= -->
@@ -107,8 +119,8 @@ diff -urN ../resources-original/ogc/sweCommon/2.0/basic_types.xsd ogc/sweCommon/
  			  <attributeGroup ref="swe:AssociationAttributeGroup"/>
  			</extension>
 diff -urN ../resources-original/ogc/wcs/1.0.0/wcsCapabilities.xsd ogc/wcs/1.0.0/wcsCapabilities.xsd
---- ../resources-original/ogc/wcs/1.0.0/wcsCapabilities.xsd	Sat Jul 21 21:59:38 2012
-+++ ogc/wcs/1.0.0/wcsCapabilities.xsd	Thu Sep 10 23:50:32 2015
+--- ../resources-original/ogc/wcs/1.0.0/wcsCapabilities.xsd	Fri Sep 11 11:09:39 2015
++++ ogc/wcs/1.0.0/wcsCapabilities.xsd	Fri Sep 11 11:10:54 2015
 @@ -444,9 +444,9 @@
          </xs:annotation>
          <xs:complexContent>

--- a/schemas/src/main/resources/ogc/ows/1.1.0/owsContents.xsd
+++ b/schemas/src/main/resources/ogc/ows/1.1.0/owsContents.xsd
@@ -84,4 +84,8 @@ elementFormDefault="qualified" version="1.1.0.3" xml:lang="en">
 		</complexContent>
 	</complexType>
 	<!-- ===========================================================-->
+	
+	<!-- This is to force JAXB generate reference properties -->
+	<element name="DatasetDescriptionSummaryExtension" type="ows:DatasetDescriptionSummaryBaseType" substitutionGroup="ows:DatasetDescriptionSummary"/>
+	<element name="OtherSourceExtension" type="ows:MetadataType" substitutionGroup="ows:OtherSource"/>
 </schema>

--- a/wmts/1.0/src/test/java/net/opengis/wmts/v_1_0/tests/WMTS_V_1_0_Test.java
+++ b/wmts/1.0/src/test/java/net/opengis/wmts/v_1_0/tests/WMTS_V_1_0_Test.java
@@ -1,0 +1,72 @@
+package net.opengis.wmts.v_1_0.tests;
+
+import java.util.List;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBElement;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Unmarshaller;
+import javax.xml.transform.stream.StreamSource;
+
+import net.opengis.ows.v_1_1_0.CodeType;
+import net.opengis.ows.v_1_1_0.DatasetDescriptionSummaryBaseType;
+import net.opengis.wmts.v_1_0.Capabilities;
+import net.opengis.wmts.v_1_0.ObjectFactory;
+import net.opengis.wmts.v_1_0.TileMatrixSet;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class WMTS_V_1_0_Test {
+
+    private JAXBContext context;
+
+    @Before
+    public void initializeContext() throws JAXBException {
+        this.context = JAXBContext.newInstance(ObjectFactory.class.getPackage()
+                .getName()
+                + ":"
+                + net.opengis.ows.v_1_1_0.ObjectFactory.class.getPackage()
+                        .getName());
+    }
+
+    @Test
+    public void unmarshalsGetCapabiltities() throws JAXBException {
+        Unmarshaller unmarshaller = this.context.createUnmarshaller();
+
+        JAXBElement<Capabilities> capablitiesElement = unmarshaller.unmarshal(
+                new StreamSource(getClass().getResourceAsStream(
+                        "wmtsGetCapabilities_response.xml")),
+                Capabilities.class);
+
+        Capabilities capabilities = capablitiesElement.getValue();
+
+        Assert.assertEquals("Web Map Tile Service", capabilities
+                .getServiceIdentification().getTitle().get(0).getValue());
+
+    }
+
+    @Test
+    public void unmarshalsGetLayersFromCapabiltities() throws JAXBException {
+        Unmarshaller unmarshaller = this.context.createUnmarshaller();
+
+        JAXBElement<Capabilities> capablitiesElement = unmarshaller.unmarshal(
+                new StreamSource(getClass().getResourceAsStream(
+                        "wmtsGetCapabilities_response.xml")),
+                Capabilities.class);
+
+        Capabilities capabilities = capablitiesElement.getValue();
+        List<TileMatrixSet> tileMatrixSets = capabilities.getContents()
+                .getTileMatrixSet();
+        Assert.assertEquals(1, tileMatrixSets.size());
+        final List<JAXBElement<DatasetDescriptionSummaryBaseType>> datasetDescriptionSummaries = capabilities
+                .getContents().getDatasetDescriptionSummary();
+        Assert.assertEquals(1, datasetDescriptionSummaries.size());
+        JAXBElement<DatasetDescriptionSummaryBaseType> coastlinesElement = datasetDescriptionSummaries.get(0);
+        DatasetDescriptionSummaryBaseType coastlines = coastlinesElement.getValue();
+        CodeType clct = coastlines.getIdentifier();
+        Assert.assertEquals("coastlines", clct.getValue());
+    }
+
+}

--- a/wmts/1.0/src/test/resources/net/opengis/wmts/v_1_0/tests/wmtsGetCapabilities_response.xml
+++ b/wmts/1.0/src/test/resources/net/opengis/wmts/v_1_0/tests/wmtsGetCapabilities_response.xml
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- This is an example of a GetCapabilities response -->
+<Capabilities xmlns="http://www.opengis.net/wmts/1.0" xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:gml="http://www.opengis.net/gml" xsi:schemaLocation="http://www.opengis.net/wmts/1.0 http://schemas.opengis.net/wmts/1.0/wmtsGetCapabilities_response.xsd" version="1.0.0">
+	<ows:ServiceIdentification>
+		<ows:Title>Web Map Tile Service</ows:Title>
+		<ows:Abstract>Service that contrains the map access interface to some TileMatrixSets</ows:Abstract>
+		<ows:Keywords>
+			<ows:Keyword>tile</ows:Keyword>
+			<ows:Keyword>tile matrix set</ows:Keyword>
+			<ows:Keyword>map</ows:Keyword>
+		</ows:Keywords>
+		<ows:ServiceType>OGC WMTS</ows:ServiceType>
+		<ows:ServiceTypeVersion>1.0.0</ows:ServiceTypeVersion>
+		<ows:Fees>none</ows:Fees>
+		<ows:AccessConstraints>none</ows:AccessConstraints>
+	</ows:ServiceIdentification>
+	<ows:ServiceProvider>
+		<ows:ProviderName>MiraMon</ows:ProviderName>
+		<ows:ProviderSite xlink:href="http://www.creaf.uab.es/miramon"/>
+		<ows:ServiceContact>
+			<ows:IndividualName>Joan Maso Pau</ows:IndividualName>
+			<ows:PositionName>Senior Software Engineer</ows:PositionName>
+			<ows:ContactInfo>
+				<ows:Phone>
+					<ows:Voice>+34 93 581 1312</ows:Voice>
+					<ows:Facsimile>+34 93 581 4151</ows:Facsimile>
+				</ows:Phone>
+				<ows:Address>
+					<ows:DeliveryPoint>Fac Ciencies UAB</ows:DeliveryPoint>
+					<ows:City>Bellaterra</ows:City>
+					<ows:AdministrativeArea>Barcelona</ows:AdministrativeArea>
+					<ows:PostalCode>08193</ows:PostalCode>
+					<ows:Country>Spain</ows:Country>
+					<ows:ElectronicMailAddress>joan.maso@uab.es</ows:ElectronicMailAddress>
+				</ows:Address>
+			</ows:ContactInfo>
+		</ows:ServiceContact>
+	</ows:ServiceProvider>
+	<ows:OperationsMetadata>
+		<ows:Operation name="GetCapabilities">
+			<ows:DCP>
+				<ows:HTTP>
+					<ows:Get xlink:href="http://www.miramon.uab.es/cgi-bin/MiraMon5_0.cgi?">
+						<ows:Constraint name="GetEncoding">
+							<ows:AllowedValues>
+								<ows:Value>KVP</ows:Value>
+							</ows:AllowedValues>
+						</ows:Constraint>
+					</ows:Get>
+				</ows:HTTP>
+			</ows:DCP>
+		</ows:Operation>
+		<ows:Operation name="GetTile">
+			<ows:DCP>
+				<ows:HTTP>
+					<ows:Get xlink:href="http://www.miramon.uab.es/cgi-bin/MiraMon5_0.cgi?"/>
+				</ows:HTTP>
+			</ows:DCP>
+		</ows:Operation>
+		<ows:Operation name="GetFeatureInfo">
+			<ows:DCP>
+				<ows:HTTP>
+					<ows:Get xlink:href="http://www.miramon.uab.es/cgi-bin/MiraMon5_0.cgi?"/>
+				</ows:HTTP>
+			</ows:DCP>
+		</ows:Operation>
+	</ows:OperationsMetadata>
+	<Contents>
+		<Layer>
+			<ows:Title>Coastlines</ows:Title>
+			<ows:Abstract>Coastline/shorelines (BA010)</ows:Abstract>
+			<ows:WGS84BoundingBox>
+				<ows:LowerCorner>-180 -90</ows:LowerCorner>
+				<ows:UpperCorner>180 90</ows:UpperCorner>
+			</ows:WGS84BoundingBox>
+			<ows:Identifier>coastlines</ows:Identifier>
+			<Style isDefault="true">
+				<ows:Title>Dark Blue</ows:Title>
+				<ows:Identifier>DarkBlue</ows:Identifier>
+				<LegendURL format="image/png" xlink:href="http://www.miramon.uab.es/wmts/Coastlines/coastlines_darkBlue.png"/>
+			</Style>
+			<Style>
+				<ows:Title>Thick And Red</ows:Title>
+				<ows:Abstract>Specify this style if you want your maps to have thick red coastlines.
+				</ows:Abstract>
+				<ows:Identifier>thickAndRed</ows:Identifier>
+			</Style>
+			<Format>image/png</Format>
+			<Format>image/gif</Format>
+			<Dimension>
+				<ows:Title>Time</ows:Title>
+				<ows:Abstract>Monthly datasets</ows:Abstract>
+				<ows:Identifier>TIME</ows:Identifier>
+				<Value>2007-05</Value>
+				<Value>2007-06</Value>
+				<Value>2007-07</Value>
+			</Dimension>
+			<TileMatrixSetLink>
+				<TileMatrixSet>BigWorld</TileMatrixSet>
+			</TileMatrixSetLink>
+		</Layer>
+		<!-- [ ... other layers ... ] -->
+		<TileMatrixSet>
+			<!-- optional bounding box of data in this CRS -->
+			<ows:Identifier>BigWorld</ows:Identifier>
+			<ows:SupportedCRS>urn:ogc:def:crs:OGC:1.3:CRS84</ows:SupportedCRS>
+			<TileMatrix>
+				<ows:Identifier>1e6</ows:Identifier>
+				<ScaleDenominator>1e6</ScaleDenominator>
+				<!-- top left point of tile matrix bounding box -->
+				<TopLeftCorner> -180 84</TopLeftCorner>
+				<!-- width and height of each tile in pixel units -->
+				<TileWidth>256</TileWidth>
+				<TileHeight>256</TileHeight>
+				<!-- width and height of matrix in tile units -->
+				<MatrixWidth>60000</MatrixWidth>
+				<MatrixHeight>50000</MatrixHeight>
+			</TileMatrix>
+			<TileMatrix>
+				<ows:Identifier>2.5e6</ows:Identifier>
+				<ScaleDenominator>2.5e6</ScaleDenominator>
+				<TopLeftCorner>-180 84</TopLeftCorner>
+				<TileWidth>256</TileWidth>
+				<TileHeight>256</TileHeight>
+				<MatrixWidth>9000</MatrixWidth>
+				<MatrixHeight>7000</MatrixHeight>
+			</TileMatrix>
+		</TileMatrixSet>
+	</Contents>
+	<Themes>
+		<Theme>
+			<ows:Title>Foundation</ows:Title>
+			<ows:Abstract>"Digital Chart Of The World" data</ows:Abstract>
+			<ows:Identifier>Foundation</ows:Identifier>
+			<Theme>
+				<ows:Title>Boundaries</ows:Title>
+				<ows:Identifier>Boundaries</ows:Identifier>
+				<LayerRef>coastlines</LayerRef>
+				<LayerRef>politicalBoundaries</LayerRef>
+				<LayerRef>depthContours</LayerRef>
+			</Theme>
+			<Theme>
+				<ows:Title>Transportation</ows:Title>
+				<ows:Identifier>Transportation</ows:Identifier>
+				<LayerRef>roads</LayerRef>
+				<LayerRef>railroads</LayerRef>
+				<LayerRef>airports</LayerRef>
+			</Theme>
+		</Theme>
+		<Theme>
+			<ows:Title>World Geology</ows:Title>
+			<ows:Identifier>World Geology</ows:Identifier>
+			<LayerRef>worldAgeRockType</LayerRef>
+			<LayerRef>worldFaultLines</LayerRef>
+			<LayerRef>felsicMagmatic</LayerRef>
+			<LayerRef>maficMagmatic</LayerRef>
+		</Theme>
+	</Themes>
+</Capabilities>


### PR DESCRIPTION
This was something that we had fixed in the 1.1.0 OGC Schemas project.  Without this change, we cannot work with the service contents.