### PR TITLE
Missing oseo module declaration, which prevented the OGC Schema scrip…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,7 @@
 		<module>kml</module>
 		<module>ols</module>
 		<module>om</module>
+		<module>oseo</module>
 		<module>owc</module>
 		<module>ows</module>
 		<module>sampling</module>


### PR DESCRIPTION
…ts module from executing as it was looking for an oseo module that was not built.