### PR TITLE
Corrected WCS Extension namespace mistakes.

### DIFF
--- a/schemas/src/main/patches/ogc.patch
+++ b/schemas/src/main/patches/ogc.patch
@@ -661,3 +661,37 @@ diff -urN ../resources-original/ogc/wms/1.3.0/capabilities_1_3_0.xsd ogc/wms/1.3
 +	<element name="OtherExtendedCapabilities" substitutionGroup="wms:_ExtendedCapabilities"/>
 +	<element name="OtherExtendedOperation" type="wms:OperationType" substitutionGroup="wms:_ExtendedOperation"/>
  </schema>
+diff -urN ../resources-original/ogc/wcs/interpolation/1.0/wcsInt.xsd ogc/wcs/interpolation/1.0/wcsInt.xsd
+--- ../resources-original/ogc/wcs/interpolation/1.0/wcsInt.xsd	2014-11-18 16:32:21.000000000 -0400
++++ ogc/wcs/interpolation/1.0/wcsInt.xsd	2015-12-18 14:45:09.167061700 -0400
+@@ -1,6 +1,6 @@
+ <?xml version="1.0" encoding="UTF-8"?>
+-<schema targetNamespace="http://www.opengis.net/WCS_service-extension_interpolation/1.0" 
+-    xmlns:int="http://www.opengis.net/WCS_service-extension_interpolation/1.0"
++<schema targetNamespace="http://www.opengis.net/wcs/interpolation/1.0" 
++    xmlns:int="http://www.opengis.net/wcs/interpolation/1.0"
+     xmlns="http://www.w3.org/2001/XMLSchema" 
+     elementFormDefault="qualified" version="1.0.0" xml:lang="en">
+     <annotation>
+diff -urN ../resources-original/ogc/wcs/processing/2.0/wcsProcessCoverages.xsd ogc/wcs/processing/2.0/wcsProcessCoverages.xsd
+--- ../resources-original/ogc/wcs/processing/2.0/wcsProcessCoverages.xsd	2014-11-26 11:41:48.000000000 -0400
++++ ogc/wcs/processing/2.0/wcsProcessCoverages.xsd	2015-12-18 14:41:53.273474300 -0400
+@@ -1,6 +1,6 @@
+ <?xml version="1.0" encoding="UTF-8"?>
+-<xs:schema targetNamespace="http://www.opengis.net/wcs_service-extension_processing/2.0"
+-    xmlns:proc="http://www.opengis.net/wcs_service-extension_processing/2.0"
++<xs:schema targetNamespace="http://www.opengis.net/wcs/processing/2.0"
++    xmlns:proc="http://www.opengis.net/wcs/processing/2.0"
+     xmlns:wcs="http://www.opengis.net/wcs/2.0"
+     xmlns:gmlcov="http://www.opengis.net/gmlcov/1.0"
+     xmlns:gml="http://www.opengis.net/gml/3.2.1"
+diff -urN ../resources-original/ogc/wcs/scaling/1.0/wcsScal.xsd ogc/wcs/scaling/1.0/wcsScal.xsd
+--- ../resources-original/ogc/wcs/scaling/1.0/wcsScal.xsd	2014-11-18 12:14:18.000000000 -0400
++++ ogc/wcs/scaling/1.0/wcsScal.xsd	2015-12-18 14:47:17.141857900 -0400
+@@ -1,5 +1,5 @@
+ <?xml version="1.0" encoding="UTF-8"?>
+-<schema xmlns:scal="http://www.opengis.net/WCS_service-extension_scaling/1.0" xmlns="http://www.w3.org/2001/XMLSchema" xmlns:ns1="http://www.opengis.net/wcs/2.0" targetNamespace="http://www.opengis.net/WCS_service-extension_scaling/1.0" elementFormDefault="qualified" version="1.0.0" xml:lang="en">
++<schema xmlns:scal="http://www.opengis.net/wcs/scaling/1.0" xmlns="http://www.w3.org/2001/XMLSchema" xmlns:wcs="http://www.opengis.net/wcs/2.0" targetNamespace="http://www.opengis.net/wcs/scaling/1.0" elementFormDefault="qualified" version="1.0.0" xml:lang="en">
+ 	<annotation>
+ 		<appinfo>scal.xsd</appinfo>
+ 		<documentation>This XML Schema Document is part of the WCS Scaling Extension [OGC 12-039]. It encodes the elements and types that allow expressing Scaling in WCS client/server communication.

--- a/schemas/src/main/resources/ogc/wcs/interpolation/1.0/wcsInt.xsd
+++ b/schemas/src/main/resources/ogc/wcs/interpolation/1.0/wcsInt.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<schema targetNamespace="http://www.opengis.net/WCS_service-extension_interpolation/1.0" 
-    xmlns:int="http://www.opengis.net/WCS_service-extension_interpolation/1.0"
+<schema targetNamespace="http://www.opengis.net/wcs/interpolation/1.0" 
+    xmlns:int="http://www.opengis.net/wcs/interpolation/1.0"
     xmlns="http://www.w3.org/2001/XMLSchema" 
     elementFormDefault="qualified" version="1.0.0" xml:lang="en">
     <annotation>

--- a/schemas/src/main/resources/ogc/wcs/processing/2.0/wcsProcessCoverages.xsd
+++ b/schemas/src/main/resources/ogc/wcs/processing/2.0/wcsProcessCoverages.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema targetNamespace="http://www.opengis.net/wcs_service-extension_processing/2.0"
-    xmlns:proc="http://www.opengis.net/wcs_service-extension_processing/2.0"
+<xs:schema targetNamespace="http://www.opengis.net/wcs/processing/2.0"
+    xmlns:proc="http://www.opengis.net/wcs/processing/2.0"
     xmlns:wcs="http://www.opengis.net/wcs/2.0"
     xmlns:gmlcov="http://www.opengis.net/gmlcov/1.0"
     xmlns:gml="http://www.opengis.net/gml/3.2.1"

--- a/schemas/src/main/resources/ogc/wcs/scaling/1.0/wcsScal.xsd
+++ b/schemas/src/main/resources/ogc/wcs/scaling/1.0/wcsScal.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<schema xmlns:scal="http://www.opengis.net/WCS_service-extension_scaling/1.0" xmlns="http://www.w3.org/2001/XMLSchema" xmlns:ns1="http://www.opengis.net/wcs/2.0" targetNamespace="http://www.opengis.net/WCS_service-extension_scaling/1.0" elementFormDefault="qualified" version="1.0.0" xml:lang="en">
+<schema xmlns:scal="http://www.opengis.net/wcs/scaling/1.0" xmlns="http://www.w3.org/2001/XMLSchema" xmlns:wcs="http://www.opengis.net/wcs/2.0" targetNamespace="http://www.opengis.net/wcs/scaling/1.0" elementFormDefault="qualified" version="1.0.0" xml:lang="en">
 	<annotation>
 		<appinfo>scal.xsd</appinfo>
 		<documentation>This XML Schema Document is part of the WCS Scaling Extension [OGC 12-039]. It encodes the elements and types that allow expressing Scaling in WCS client/server communication.


### PR DESCRIPTION
The namespace URIs do not match those in the specifications.  After asking the WCS working group about this, it was confirmed this is in error and they plan on updating them (at some point).

Once that's done (whenever that is) this change set can be reverted.